### PR TITLE
Publish UPM package to public registry

### DIFF
--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/.npmrc
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/.npmrc
@@ -1,3 +1,3 @@
-registry=https://microsoft.pkgs.visualstudio.com/Analog/_packaging/MixedReality-UPM-Internal/npm/registry/ 
+registry=https://pkgs.dev.azure.com/aipmr/MixedReality-Unity-Packages/_packaging/Unity-packages/npm/registry/
 
 always-auth=true

--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/package.json
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/package.json
@@ -2,7 +2,7 @@
   "name": "com.microsoft.spatialaudio.spatializer.unity",
   "displayName": "Microsoft Spatializer",
   "version": "%version%",
-  "unity": "2018.4",
+  "unity": "2019.4",
   "description": "Audio Spatializer for HoloLens and Windows Mixed Reality applications",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
This publishes the package to the public registry and scopes the package to Unity 2019.4 and greater (aligns with MRTK).