### PR TITLE
Add asmdefs and namespaces to package scripts

### DIFF
--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Editor/Microsoft.SpatialAudio.Spatializer.Editor.asmdef
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Editor/Microsoft.SpatialAudio.Spatializer.Editor.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "Microsoft.SpatialAudio.Spatializer.Editor",
+    "references": [
+        "Microsoft.SpatialAudio.Spatializer"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Editor/Microsoft.SpatialAudio.Spatializer.Editor.asmdef.meta
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Editor/Microsoft.SpatialAudio.Spatializer.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ef22c339df0cc8a4cafdd037deebf5b5
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Editor/RoomEffectSendLevelEditor.cs
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Editor/RoomEffectSendLevelEditor.cs
@@ -1,23 +1,26 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using UnityEditor;
-using UnityEngine;
 
-[CustomEditor(typeof(RoomEffectSendLevel))]
-[CanEditMultipleObjects]
-public class RoomEffectSendLevelEditor : Editor
+namespace Microsoft.SpatialAudio.Spatializer.Editor
 {
-    private SerializedProperty RoomEffectSendPowerCurve;
-
-    public void OnEnable()
+    [CustomEditor(typeof(RoomEffectSendLevel))]
+    [CanEditMultipleObjects]
+    public class RoomEffectSendLevelEditor : UnityEditor.Editor
     {
-        RoomEffectSendPowerCurve = serializedObject.FindProperty("RoomEffectSendPowerCurve");
-    }
+        private SerializedProperty RoomEffectSendPowerCurve;
 
-    public override void OnInspectorGUI()
-    {
-        serializedObject.UpdateIfRequiredOrScript();
-        EditorGUILayout.PropertyField(RoomEffectSendPowerCurve);
-        serializedObject.ApplyModifiedProperties();
+        public void OnEnable()
+        {
+            RoomEffectSendPowerCurve = serializedObject.FindProperty("RoomEffectSendPowerCurve");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.UpdateIfRequiredOrScript();
+            EditorGUILayout.PropertyField(RoomEffectSendPowerCurve);
+            serializedObject.ApplyModifiedProperties();
+        }
     }
 }

--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Microsoft.SpatialAudio.Spatializer.asmdef
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Microsoft.SpatialAudio.Spatializer.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "Microsoft.SpatialAudio.Spatializer",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Microsoft.SpatialAudio.Spatializer.asmdef.meta
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/Microsoft.SpatialAudio.Spatializer.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 51c961a4922da4f449eaae7928a15ea1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/RoomEffectSendLevel.cs
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Scripts/RoomEffectSendLevel.cs
@@ -1,93 +1,97 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using UnityEngine;
 using UnityEditor;
 
-[DisallowMultipleComponent]
-[RequireComponent(typeof(AudioSource))]
-public class RoomEffectSendLevel : MonoBehaviour
+namespace Microsoft.SpatialAudio.Spatializer
 {
-    private const float c_RoomEffectSendPowerMin = -100;
-    private const float c_RoomEffectSendPowerMax = 20;
-    private const float c_RoomEffectSendPowerMaxDistance = 100;
-
-    private const string c_RoomEffectSendPowerLabel = "Room Effect Send Level (dB)";
-
-    // Spatializer parameter indices
-    public enum SpatializerParams
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(AudioSource))]
+    public class RoomEffectSendLevel : MonoBehaviour
     {
-        RoomEffectSendPower = 0,
-        Count
-    }
+        private const float c_RoomEffectSendPowerMin = -100;
+        private const float c_RoomEffectSendPowerMax = 20;
+        private const float c_RoomEffectSendPowerMaxDistance = 100;
 
-    [CurveDimensions(0, c_RoomEffectSendPowerMaxDistance, c_RoomEffectSendPowerMin, c_RoomEffectSendPowerMax, c_RoomEffectSendPowerLabel)]
-    [Tooltip("Calculate the amount of non-spatialized source signal that should be processed for the room effect (typically reverb) in dB based on the source-listener distance. Default=0dB, Range [-100dB,20dB]")]
-    [ContextMenuItem("Reset", "ResetRoomEffectSendPowerCurve")]
-    public AnimationCurve RoomEffectSendPowerCurve = AnimationCurve.Linear(0, 0, c_RoomEffectSendPowerMaxDistance, 0);
+        private const string c_RoomEffectSendPowerLabel = "Room Effect Send Level (dB)";
 
-    private float _LastRoomEffectSendPower = float.MinValue;
+        // Spatializer parameter indices
+        public enum SpatializerParams
+        {
+            RoomEffectSendPower = 0,
+            Count
+        }
 
-    private void ResetRoomEffectSendPowerCurve()
-    {
-        RoomEffectSendPowerCurve = AnimationCurve.Linear(0, 0, c_RoomEffectSendPowerMaxDistance, 0);
+        [CurveDimensions(0, c_RoomEffectSendPowerMaxDistance, c_RoomEffectSendPowerMin, c_RoomEffectSendPowerMax, c_RoomEffectSendPowerLabel)]
+        [Tooltip("Calculate the amount of non-spatialized source signal that should be processed for the room effect (typically reverb) in dB based on the source-listener distance. Default=0dB, Range [-100dB,20dB]")]
+        [ContextMenuItem("Reset", "ResetRoomEffectSendPowerCurve")]
+        public AnimationCurve RoomEffectSendPowerCurve = AnimationCurve.Linear(0, 0, c_RoomEffectSendPowerMaxDistance, 0);
+
+        private float _LastRoomEffectSendPower = float.MinValue;
+
+        private void ResetRoomEffectSendPowerCurve()
+        {
+            RoomEffectSendPowerCurve = AnimationCurve.Linear(0, 0, c_RoomEffectSendPowerMaxDistance, 0);
 
 #if UNITY_EDITOR
-        // This forces the inspector preview of the animation curve to refresh
-        AssetDatabase.Refresh();
+            // This forces the inspector preview of the animation curve to refresh
+            AssetDatabase.Refresh();
 #endif
-    }
+        }
 
-    void Update()
-    {
-        var source = GetComponent<AudioSource>();
-
-        // Source-listener distance
-        float distance = Vector3.Distance(transform.position, Camera.main.transform.position);
-
-        // Get the room effect send level for this distance
-        float roomEffectSendPower = RoomEffectSendPowerCurve.Evaluate(distance);
-
-        if (_LastRoomEffectSendPower != roomEffectSendPower)
+        void Update()
         {
-            _LastRoomEffectSendPower = roomEffectSendPower;
-            source.SetSpatializerFloat((int)SpatializerParams.RoomEffectSendPower, _LastRoomEffectSendPower);
+            var source = GetComponent<AudioSource>();
+
+            // Source-listener distance
+            float distance = Vector3.Distance(transform.position, Camera.main.transform.position);
+
+            // Get the room effect send level for this distance
+            float roomEffectSendPower = RoomEffectSendPowerCurve.Evaluate(distance);
+
+            if (_LastRoomEffectSendPower != roomEffectSendPower)
+            {
+                _LastRoomEffectSendPower = roomEffectSendPower;
+                source.SetSpatializerFloat((int)SpatializerParams.RoomEffectSendPower, _LastRoomEffectSendPower);
+            }
         }
     }
-}
 
 #if UNITY_EDITOR
-/// <summary>
-/// Custom drawer for the startup of AnimationCurves. Sets the grid range for the curve editor.
-/// </summary>
-[CustomPropertyDrawer(typeof(CurveDimensions))]
-public class CurveDrawer : PropertyDrawer
-{
-    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    /// <summary>
+    /// Custom drawer for the startup of AnimationCurves. Sets the grid range for the curve editor.
+    /// </summary>
+    [CustomPropertyDrawer(typeof(CurveDimensions))]
+    public class CurveDrawer : PropertyDrawer
     {
-        var curve = attribute as CurveDimensions;
-        if (property.propertyType == SerializedPropertyType.AnimationCurve)
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var rect = new Rect(curve.XMin, curve.YMin, System.Math.Abs(curve.XMin - curve.XMax), System.Math.Abs(curve.YMin - curve.YMax));
-            EditorGUI.CurveField(position, property, Color.green, rect, new GUIContent(curve.Label));
+            var curve = attribute as CurveDimensions;
+            if (property.propertyType == SerializedPropertyType.AnimationCurve)
+            {
+                var rect = new Rect(curve.XMin, curve.YMin, System.Math.Abs(curve.XMin - curve.XMax), System.Math.Abs(curve.YMin - curve.YMax));
+                EditorGUI.CurveField(position, property, Color.green, rect, new GUIContent(curve.Label));
+            }
         }
     }
-}
 #endif
 
-/// <summary>
-/// Property attribute for setting the CurveField grid range.
-/// </summary>
-public class CurveDimensions : PropertyAttribute
-{
-    public float XMin, XMax, YMin, YMax;
-    public string Label;
-
-    public CurveDimensions(float xMin, float xMax, float yMin, float yMax, string label)
+    /// <summary>
+    /// Property attribute for setting the CurveField grid range.
+    /// </summary>
+    public class CurveDimensions : PropertyAttribute
     {
-        this.XMin = xMin;
-        this.XMax = xMax;
-        this.YMin = yMin;
-        this.YMax = yMax;
-        this.Label = label;
+        public float XMin, XMax, YMin, YMax;
+        public string Label;
+
+        public CurveDimensions(float xMin, float xMax, float yMin, float yMax, string label)
+        {
+            this.XMin = xMin;
+            this.XMax = xMax;
+            this.YMin = yMin;
+            this.YMax = yMax;
+            this.Label = label;
+        }
     }
 }


### PR DESCRIPTION
In preparation for UPM, any scripts need to be contained in an assembly definition. Otherwise, when imported into Unity via the Package Manager, you'll see the following: 

![image](https://user-images.githubusercontent.com/3580640/96065309-2f135980-0e4d-11eb-8701-23c3c2a59e98.png)

```
Script 'Packages/com.microsoft.spatialaudio.spatializer.unity/Scripts/RoomEffectSendLevel.cs' will not be compiled because it exists outside the Assets folder and does not to belong to any assembly definition file.
UnityEditor.Scripting.ScriptCompilation.EditorCompilationInterface:TickCompilationPipeline(EditorScriptCompilationOptions, BuildTargetGroup, BuildTarget)
```

This PR adds both runtime and editor-only asmdef files, as well as adding namespaces to the corresponding scripts.

Recommend viewing with whitespace changes hidden, to make the actual additions more clear: https://github.com/microsoft/spatialaudio-unity/pull/23/files?diff=split&w=1

![image](https://user-images.githubusercontent.com/3580640/96066936-a5b05700-0e4d-11eb-8ed4-cb59e717890b.png)
