### PR TITLE
Update author name in package.json

### DIFF
--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/package.json
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/package.json
@@ -15,7 +15,7 @@
     "virtual",
     "hololens"
   ],
-  "author": "Microsoft Corporation",
+  "author": "Microsoft",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
To align with https://github.com/microsoft/MixedRealityToolkit-Unity/pull/8425 and the author name used by other packages on this feed (like [MixedReality-WebRTC](https://github.com/microsoft/MixedReality-WebRTC/blob/3e3443516196d16f072f218f23348212bfccd4b9/libs/unity/library/package.json#L15) and [GpuStats](https://github.com/microsoft/MixedRealityToolkit/blob/0c6ee792922d04c474e915e7d49fd140b72949a8/GpuStats/UnityAddon/package.json#L15), I've updated the author name from "Microsoft Corporation" to "Microsoft".

Unity groups packages by their author in the UI, so this will help keep our packages grouped together!

![image](https://user-images.githubusercontent.com/3580640/96069655-83b9d300-0e53-11eb-8c4d-843ad3e9491a.png)
