### PR TITLE
Publish plugin to public UPM feed

### DIFF
--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -90,7 +90,7 @@ jobs:
       customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-  - script: python tools\upm_package.py -o "$(Pipeline.Workspace)\npm" -t "$(NpmPackageName)-$(ProductVersion).tgz" -d
+  - script: python tools\upm_package.py -t "$(Pipeline.Workspace)\npm\$(NpmPackageName)-$(ProductVersion).tgz" -d
     displayName: Dry run publish public NPM Package
     continueOnError: 'false'
   - task: PublishBuildArtifacts@1

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -90,7 +90,7 @@ jobs:
       customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-  - script: python  $(Build.SourcesDirectory)\Tools\upm_package.py -t $(NpmPackageName)-$(ProductVersion).tgz -d
+  - script: python  $(Build.SourcesDirectory)\Tools\upm_package.py -o "$(Pipeline.Workspace)\npm" -t $(NpmPackageName)-$(ProductVersion).tgz -d
     displayName: Dry run publish public NPM Package
     workingDirectory: $(Pipeline.Workspace)\npm\
     continueOnError: 'false'

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -87,7 +87,7 @@ jobs:
     displayName: Public NPM Feed Authentication
     inputs:
       workingFile: Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\.npmrc
-      customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
+      customEndpoint: 'AIPMR Acoustics UPM Feed'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
   - script: python tools\upm_package.py -t "$(Pipeline.Workspace)\npm\$(NpmPackageName)-$(ProductVersion).tgz" -d

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -90,7 +90,8 @@ jobs:
       customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-  - script: npm publish $(NpmPackageName)-$(ProductVersion).tgz --access public --dry-run
+    workingDirectory: $(Pipeline.Workspace)\npm\
+  - script: python tools\upm_package.py -t $(NpmPackageName)-$(ProductVersion).tgz -d
     displayName: Dry run publish public NPM Package
     workingDirectory: $(Pipeline.Workspace)\npm\
     continueOnError: 'false'

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -91,7 +91,7 @@ jobs:
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
     workingDirectory: $(Pipeline.Workspace)\npm\
-  - script: python tools\upm_package.py -t $(NpmPackageName)-$(ProductVersion).tgz -d
+  - script: python upm_package.py -t $(NpmPackageName)-$(ProductVersion).tgz -d
     displayName: Dry run publish public NPM Package
     workingDirectory: $(Pipeline.Workspace)\npm\
     continueOnError: 'false'

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -90,7 +90,7 @@ jobs:
       customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-  - script: npm publish '$(NpmPackageName)-$(ProductVersion).tgz' --access public --dry-run
+  - script: npm publish $(NpmPackageName)-$(ProductVersion).tgz --access public --dry-run
     displayName: Dry run publish public NPM Package
     workingDirectory: $(Pipeline.Workspace)\npm\
     continueOnError: 'false'

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -90,9 +90,8 @@ jobs:
       customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-  - script: python  $(Build.SourcesDirectory)\Tools\upm_package.py -o "$(Pipeline.Workspace)\npm" -t $(NpmPackageName)-$(ProductVersion).tgz -d
+  - script: python tools\upm_package.py -o "$(Pipeline.Workspace)\npm" -t "$(NpmPackageName)-$(ProductVersion).tgz" -d
     displayName: Dry run publish public NPM Package
-    workingDirectory: $(Pipeline.Workspace)\npm\
     continueOnError: 'false'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish NPM Package to Fileshare'

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -90,7 +90,7 @@ jobs:
       customEndpoint: 'aipmr MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-  - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion) -p -d
+  - script: python tools\upm_package.py -t "$(Pipeline.Workspace)\npm\$(NpmPackageName)-$(ProductVersion).tgz" -d
     displayName: Dry run publish public NPM Package
     continueOnError: 'false'
   - task: PublishBuildArtifacts@1

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -77,7 +77,7 @@ jobs:
     displayName: Internal NPM Feed Authentication
     inputs:
       workingFile: Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\.npmrc
-  - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion) -p -d
+  - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion) -p
     displayName: Publish NPM Package to Internal Feed
   - task: CmdLine@2
     displayName: Copy .npmrc for Public Feed

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -77,7 +77,7 @@ jobs:
     displayName: Internal NPM Feed Authentication
     inputs:
       workingFile: Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\.npmrc
-  - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion) -p
+  - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion) -p -d
     displayName: Publish NPM Package to Internal Feed
   - task: CmdLine@2
     displayName: Copy .npmrc for Public Feed
@@ -90,7 +90,7 @@ jobs:
       customEndpoint: 'AIPMR Acoustics UPM Feed'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-  - script: python tools\upm_package.py -t "$(Pipeline.Workspace)\npm\$(NpmPackageName)-$(ProductVersion).tgz" -d
+  - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion) -p -d
     displayName: Dry run publish public NPM Package
     continueOnError: 'false'
   - task: PublishBuildArtifacts@1

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -86,8 +86,8 @@ jobs:
   - task: npmAuthenticate@0
     displayName: Public NPM Feed Authentication
     inputs:
-      workingFile: Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\.npmrc
-      customEndpoint: 'AIPMR Acoustics UPM Feed'
+      workingFile: 'Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/.npmrc'
+      customEndpoint: 'aipmr MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion) -p -d

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -83,16 +83,8 @@ jobs:
     displayName: Copy .npmrc for Public Feed
     inputs:
       script: copy $(Build.SourcesDirectory)\Tools\PublicFeed.npmrc $(Build.SourcesDirectory)\Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\.npmrc
-  - task: npmAuthenticate@0
-    displayName: Public NPM Feed Authentication
-    inputs:
-      workingFile: 'Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/.npmrc'
-      customEndpoint: 'aipmr MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-  - script: python tools\upm_package.py -t "$(Pipeline.Workspace)\npm\$(NpmPackageName)-$(ProductVersion).tgz" -d
-    displayName: Dry run publish public NPM Package
-    continueOnError: 'false'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish NPM Package to Fileshare'
     inputs:
@@ -104,6 +96,6 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish NPM Package to Build Artifacts'
     inputs:
-      PathtoPublish: '$(Pipeline.Workspace)\npm'
+      PathtoPublish: '$(Build.SourcesDirectory)\Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\'
       ArtifactName: 'NpmPackage'
 

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -88,9 +88,8 @@ jobs:
     inputs:
       workingFile: Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\.npmrc
       customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
-  - script: python  $(Build.SourcesDirectory)\tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
+  - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
-    workingDirectory: $(Pipeline.Workspace)\npm\
   - script: python  $(Build.SourcesDirectory)\Tools\upm_package.py -t $(NpmPackageName)-$(ProductVersion).tgz -d
     displayName: Dry run publish public NPM Package
     workingDirectory: $(Pipeline.Workspace)\npm\

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -90,6 +90,10 @@ jobs:
       customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
+  - script: npm publish '$(NpmPackageName)-$(ProductVersion).tgz' --access public --dry-run
+    displayName: Dry run publish public NPM Package
+    workingDirectory: $(Pipeline.Workspace)\npm\
+    continueOnError: 'false'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish NPM Package to Fileshare'
     inputs:

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -88,10 +88,10 @@ jobs:
     inputs:
       workingFile: Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\.npmrc
       customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
-  - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
+  - script: python  $(Build.SourcesDirectory)\tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion)
     displayName: Build Public NPM Package
     workingDirectory: $(Pipeline.Workspace)\npm\
-  - script: python upm_package.py -t $(NpmPackageName)-$(ProductVersion).tgz -d
+  - script: python  $(Build.SourcesDirectory)\Tools\upm_package.py -t $(NpmPackageName)-$(ProductVersion).tgz -d
     displayName: Dry run publish public NPM Package
     workingDirectory: $(Pipeline.Workspace)\npm\
     continueOnError: 'false'

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -3,7 +3,7 @@
 
 jobs:
 - deployment: Publish
-  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
   continueOnError: false
   displayName: Publish Packages to Feeds
   pool:

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -28,7 +28,7 @@ jobs:
             workingFile: '$(Pipeline.Workspace)\npm\.npmrc'
             customEndpoint: 'aipmr MixedReality-Unity-Packages'
         - script: npm publish $(Pipeline.Workspace)\npm
-          displayName: Publish NPM Package to Internal Feed
+          displayName: Publish NPM Package to Public UPM Feed
 
         - script: echo Downloading Nuget Artifacts
         - task: DownloadPipelineArtifact@2

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -3,7 +3,7 @@
 
 jobs:
 - deployment: Publish
-  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
   continueOnError: false
   displayName: Publish Packages to Feeds
   pool:
@@ -26,32 +26,32 @@ jobs:
           displayName: Public NPM Feed Authentication
           inputs:
             workingFile: '$(Pipeline.Workspace)\npm\.npmrc'
-            customEndpoint: 'aipmr MixedReality-Unity-Packages'
-        - script: npm publish $(Pipeline.Workspace)\npm
+            customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
+        - script: npm publish $(Pipeline.Workspace)\npm --dry-run
           displayName: Publish NPM Package to Public UPM Feed
 
-        - script: echo Downloading Nuget Artifacts
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: 'NugetPackage'
-            buildType: 'current'
-            targetPath: '$(Pipeline.Workspace)\nuget'
-        - task: PkgESCodeSign@10
-          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
-          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          inputs:
-            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
-            signTimeOut: 360
-            inPathRoot: '$(Pipeline.Workspace)\nuget'
-            outPathRoot: '$(Pipeline.Workspace)\nuget'
-        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-          displayName: 'Push to Nuget.org'
-          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-          inputs:
-            command: 'push'
-            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
-            nuGetFeedType: 'external'
-            publishFeedCredentials: '$(NugetFeedId)'
+#        - script: echo Downloading Nuget Artifacts
+#        - task: DownloadPipelineArtifact@2
+#          inputs:
+#            artifactName: 'NugetPackage'
+#            buildType: 'current'
+#            targetPath: '$(Pipeline.Workspace)\nuget'
+#        - task: PkgESCodeSign@10
+#          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
+#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#          env:
+#            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+#          inputs:
+#            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
+#            signTimeOut: 360
+#            inPathRoot: '$(Pipeline.Workspace)\nuget'
+#            outPathRoot: '$(Pipeline.Workspace)\nuget'
+#        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+#          displayName: 'Push to Nuget.org'
+#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#          inputs:
+#            command: 'push'
+#            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
+#            nuGetFeedType: 'external'
+#            publishFeedCredentials: '$(NugetFeedId)'
 

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -3,7 +3,7 @@
 
 jobs:
 - deployment: Publish
-#  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
   continueOnError: false
   displayName: Publish Packages to Feeds
   pool:
@@ -27,31 +27,31 @@ jobs:
           inputs:
             workingFile: '$(Pipeline.Workspace)\npm\.npmrc'
             customEndpoint: 'aipmr MixedReality-Unity-Packages'
-        - script: npm publish $(Pipeline.Workspace)\npm --dry-run
+        - script: npm publish $(Pipeline.Workspace)\npm
           displayName: Publish NPM Package to Internal Feed
 
-#        - script: echo Downloading Nuget Artifacts
-#        - task: DownloadPipelineArtifact@2
-#          inputs:
-#            artifactName: 'NugetPackage'
-#            buildType: 'current'
-#            targetPath: '$(Pipeline.Workspace)\nuget'
-#        - task: PkgESCodeSign@10
-#          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
-#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-#          env:
-#            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-#          inputs:
-#            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
-#            signTimeOut: 360
-#            inPathRoot: '$(Pipeline.Workspace)\nuget'
-#            outPathRoot: '$(Pipeline.Workspace)\nuget'
-#        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-#          displayName: 'Push to Nuget.org'
-#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-#          inputs:
-#            command: 'push'
-#            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
-#            nuGetFeedType: 'external'
-#            publishFeedCredentials: '$(NugetFeedId)'
+        - script: echo Downloading Nuget Artifacts
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: 'NugetPackage'
+            buildType: 'current'
+            targetPath: '$(Pipeline.Workspace)\nuget'
+        - task: PkgESCodeSign@10
+          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          inputs:
+            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
+            signTimeOut: 360
+            inPathRoot: '$(Pipeline.Workspace)\nuget'
+            outPathRoot: '$(Pipeline.Workspace)\nuget'
+        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+          displayName: 'Push to Nuget.org'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+          inputs:
+            command: 'push'
+            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: '$(NugetFeedId)'
 

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -3,7 +3,7 @@
 
 jobs:
 - deployment: Publish
-#  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
   continueOnError: false
   displayName: Publish Packages to Feeds
   pool:
@@ -27,31 +27,31 @@ jobs:
           inputs:
             workingFile: '$(Pipeline.Workspace)\npm\.npmrc'
             customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
-        - script: npm publish $(Pipeline.Workspace)\npm --dry-run
+        - script: npm publish $(Pipeline.Workspace)\npm
           displayName: Publish NPM Package to Public UPM Feed
 
-#        - script: echo Downloading Nuget Artifacts
-#        - task: DownloadPipelineArtifact@2
-#          inputs:
-#            artifactName: 'NugetPackage'
-#            buildType: 'current'
-#            targetPath: '$(Pipeline.Workspace)\nuget'
-#        - task: PkgESCodeSign@10
-#          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
-#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-#          env:
-#            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-#          inputs:
-#            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
-#            signTimeOut: 360
-#            inPathRoot: '$(Pipeline.Workspace)\nuget'
-#            outPathRoot: '$(Pipeline.Workspace)\nuget'
-#        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-#          displayName: 'Push to Nuget.org'
-#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-#          inputs:
-#            command: 'push'
-#            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
-#            nuGetFeedType: 'external'
-#            publishFeedCredentials: '$(NugetFeedId)'
+        - script: echo Downloading Nuget Artifacts
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: 'NugetPackage'
+            buildType: 'current'
+            targetPath: '$(Pipeline.Workspace)\nuget'
+        - task: PkgESCodeSign@10
+          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          inputs:
+            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
+            signTimeOut: 360
+            inPathRoot: '$(Pipeline.Workspace)\nuget'
+            outPathRoot: '$(Pipeline.Workspace)\nuget'
+        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+          displayName: 'Push to Nuget.org'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+          inputs:
+            command: 'push'
+            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: '$(NugetFeedId)'
 

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -16,28 +16,42 @@ jobs:
         - script: echo Syncing Source
         - checkout: self
           submodules: true
-        - script: echo Downloading Nuget Artifacts
+        - script: echo Downloading NPM Artifacts
         - task: DownloadPipelineArtifact@2
           inputs:
-            artifactName: 'NugetPackage'
+            artifactName: 'NpmPackage'
             buildType: 'current'
-            targetPath: '$(Pipeline.Workspace)\nuget'
-        - task: PkgESCodeSign@10
-          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
-          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            targetPath: '$(Pipeline.Workspace)\npm'
+        - task: npmAuthenticate@0
+          displayName: Public NPM Feed Authentication
           inputs:
-            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
-            signTimeOut: 360
-            inPathRoot: '$(Pipeline.Workspace)\nuget'
-            outPathRoot: '$(Pipeline.Workspace)\nuget'
-        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-          displayName: 'Push to Nuget.org'
-          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-          inputs:
-            command: 'push'
-            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
-            nuGetFeedType: 'external'
-            publishFeedCredentials: '$(NugetFeedId)'
+            workingFile: '$(Pipeline.Workspace)\npm\.npmrc'
+            customEndpoint: 'aipmr MixedReality-Unity-Packages'
+        - script: npm publish $(Pipeline.Workspace)\npm --dry-run
+          displayName: Publish NPM Package to Internal Feed
+
+#        - script: echo Downloading Nuget Artifacts
+#        - task: DownloadPipelineArtifact@2
+#          inputs:
+#            artifactName: 'NugetPackage'
+#            buildType: 'current'
+#            targetPath: '$(Pipeline.Workspace)\nuget'
+#        - task: PkgESCodeSign@10
+#          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
+#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#          env:
+#            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+#          inputs:
+#            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
+#            signTimeOut: 360
+#            inPathRoot: '$(Pipeline.Workspace)\nuget'
+#            outPathRoot: '$(Pipeline.Workspace)\nuget'
+#        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+#          displayName: 'Push to Nuget.org'
+#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#          inputs:
+#            command: 'push'
+#            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
+#            nuGetFeedType: 'external'
+#            publishFeedCredentials: '$(NugetFeedId)'
 

--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/.npmrc
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/.npmrc
@@ -1,3 +1,3 @@
-registry=https://pkgs.dev.azure.com/aipmr/MixedReality-Unity-Packages/_packaging/Unity-packages/npm/registry/
+registry=https://microsoft.pkgs.visualstudio.com/Analog/_packaging/MixedReality-UPM-Internal/npm/registry/
 
 always-auth=true

--- a/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/package.json
+++ b/Source/Plugins/IsacPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/package.json
@@ -4,6 +4,7 @@
   "version": "%version%",
   "unity": "2019.4",
   "description": "Audio Spatializer for HoloLens and Windows Mixed Reality applications",
+  "msftFeatureCategory": "Spatial Audio",
   "keywords": [
     "microsoft",
     "mixed",

--- a/Tools/upm_package.py
+++ b/Tools/upm_package.py
@@ -66,7 +66,7 @@ def main():
         npm_command = ["cmd", "/c", "npm publish ", args.tarball]
         if args.dryrun:
             npm_command = [npm_command, "--dry-run"]
-        result = subprocess.run(npm_command, cwd=unity_project_full_path)
+        result = subprocess.run(npm_command, cwd=args.output)
         if (result.returncode != 0):
             print("Package generation failed!")
             print(result.stdout)

--- a/Tools/upm_package.py
+++ b/Tools/upm_package.py
@@ -61,6 +61,9 @@ def main():
                 npm_package_full_path = oshelpers.fixpath(unity_project_full_path, constants.spatializer_npm_package_name + "-" + args.version + ".tgz")
                 shutil.move(npm_package_full_path, npm_package_location)
                 print("Package successfully generated: " + npm_package_full_path)
+                for file in os.listdir(npm_package_location):
+                    if file.endswith(".tgz"):
+                        print("Package successfully moved to " + oshelpers.fixpath(npm_package_location, file))
             else:
                 print("Package successfully published")
     else:

--- a/Tools/upm_package.py
+++ b/Tools/upm_package.py
@@ -63,11 +63,12 @@ def main():
             else:
                 print("Package successfully published")
     else:
-        npm_command = ["cmd", "/c", "npm publish", args.tarball]
-        if args.dryrun:
-            npm_command = [npm_command, "--dry-run"]
+        if not os.path.exists(args.tarball):
+            print("Can't find tarball " + args.tarball)
+            exit
+        npm_command = ["cmd", "/c", "npm publish", args.tarball, "--dry-run" if args.dryrun else ""]
         print(npm_command)
-        result = subprocess.run(npm_command, cwd=args.output)
+        result = subprocess.run(npm_command)
         if (result.returncode != 0):
             print("Package generation failed!")
             print(result.stdout)

--- a/Tools/upm_package.py
+++ b/Tools/upm_package.py
@@ -46,10 +46,11 @@ def main():
         result = subprocess.run(["cmd", "/c", "npm version", args.version, "--allow-same-version"], cwd=unity_project_full_path)
         local_copy = False
         if args.publish:
-            npm_command = ["cmd", "/c", "npm publish"]
+            npm_command = ["cmd", "/c", "npm publish", "--dry-run" if args.dryrun else ""]
         else:
             local_copy = True
             npm_command = ["cmd", "/c", "npm pack"]
+        print(npm_command)
         result = subprocess.run(npm_command, cwd=unity_project_full_path)
         if (result.returncode != 0):
             print("Package generation failed!")

--- a/Tools/upm_package.py
+++ b/Tools/upm_package.py
@@ -42,7 +42,6 @@ def main():
             os.mkdir(npm_package_location)
 
         unity_project_full_path = oshelpers.fixpath(git_root, constants.unity_project_dir, "Assets", constants.spatializer_plugin_name)
-        npm_package_full_path = oshelpers.fixpath(npm_package_location, constants.spatializer_plugin_name + "." + args.version)
         # Specify the package version before packing
         result = subprocess.run(["cmd", "/c", "npm version", args.version, "--allow-same-version"], cwd=unity_project_full_path)
         local_copy = False
@@ -58,14 +57,16 @@ def main():
             print(result.stderr)
         else:
             if local_copy:
-                shutil.move(oshelpers.fixpath(unity_project_full_path, constants.spatializer_npm_package_name + "-" + args.version + ".tgz"), npm_package_location)
+                npm_package_full_path = oshelpers.fixpath(unity_project_full_path, constants.spatializer_npm_package_name + "-" + args.version + ".tgz")
+                shutil.move(npm_package_full_path, npm_package_location)
                 print("Package successfully generated: " + npm_package_full_path)
             else:
                 print("Package successfully published")
     else:
-        npm_command = ["cmd", "/c", "npm publish ", args.tarball]
+        npm_command = ["cmd", "/c", "npm publish", args.tarball]
         if args.dryrun:
             npm_command = [npm_command, "--dry-run"]
+        print(npm_command)
         result = subprocess.run(npm_command, cwd=args.output)
         if (result.returncode != 0):
             print("Package generation failed!")


### PR DESCRIPTION
1. Publishing phase will now push the plugin to the public UPM feed.
2. Added "dry-run" support for testing to the UPM packaging script.