### PR TITLE
Fix npm artifact path for .npmrc

### DIFF
--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -3,7 +3,7 @@
 
 jobs:
 - deployment: Publish
-  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
   continueOnError: false
   displayName: Publish Packages to Feeds
   pool:
@@ -21,37 +21,37 @@ jobs:
           inputs:
             artifactName: 'NpmPackage'
             buildType: 'current'
-            targetPath: '$(Pipeline.Workspace)\npm'
+            targetPath: '$(Pipeline.Workspace)'
         - task: npmAuthenticate@0
           displayName: Public NPM Feed Authentication
           inputs:
-            workingFile: '$(Pipeline.Workspace)\npm\.npmrc'
+            workingFile: '$(Pipeline.Workspace)\NpmPackage\.npmrc'
             customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
-        - script: npm publish $(Pipeline.Workspace)\npm
+        - script: npm publish $(Pipeline.Workspace)\NpmPackage --dry-run
           displayName: Publish NPM Package to Public UPM Feed
 
-        - script: echo Downloading Nuget Artifacts
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: 'NugetPackage'
-            buildType: 'current'
-            targetPath: '$(Pipeline.Workspace)\nuget'
-        - task: PkgESCodeSign@10
-          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
-          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          inputs:
-            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
-            signTimeOut: 360
-            inPathRoot: '$(Pipeline.Workspace)\nuget'
-            outPathRoot: '$(Pipeline.Workspace)\nuget'
-        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-          displayName: 'Push to Nuget.org'
-          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-          inputs:
-            command: 'push'
-            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
-            nuGetFeedType: 'external'
-            publishFeedCredentials: '$(NugetFeedId)'
+#        - script: echo Downloading Nuget Artifacts
+#        - task: DownloadPipelineArtifact@2
+#          inputs:
+#           artifactName: 'NugetPackage'
+#            buildType: 'current'
+#            targetPath: '$(Pipeline.Workspace)\nuget'
+#        - task: PkgESCodeSign@10
+#          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
+#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#          env:
+#            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+#          inputs:
+#            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
+#            signTimeOut: 360
+#            inPathRoot: '$(Pipeline.Workspace)\nuget'
+#            outPathRoot: '$(Pipeline.Workspace)\nuget'
+#        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+#          displayName: 'Push to Nuget.org'
+#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+#          inputs:
+#            command: 'push'
+#            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
+#            nuGetFeedType: 'external'
+#            publishFeedCredentials: '$(NugetFeedId)'
 

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -3,7 +3,7 @@
 
 jobs:
 - deployment: Publish
-#  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
   continueOnError: false
   displayName: Publish Packages to Feeds
   pool:
@@ -27,31 +27,31 @@ jobs:
           inputs:
             workingFile: '$(Pipeline.Workspace)\NpmPackage\.npmrc'
             customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
-        - script: npm publish $(Pipeline.Workspace)\NpmPackage --dry-run
+        - script: npm publish $(Pipeline.Workspace)\NpmPackage
           displayName: Publish NPM Package to Public UPM Feed
 
-#        - script: echo Downloading Nuget Artifacts
-#        - task: DownloadPipelineArtifact@2
-#          inputs:
-#           artifactName: 'NugetPackage'
-#            buildType: 'current'
-#            targetPath: '$(Pipeline.Workspace)\nuget'
-#        - task: PkgESCodeSign@10
-#          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
-#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-#          env:
-#            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-#          inputs:
-#            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
-#            signTimeOut: 360
-#            inPathRoot: '$(Pipeline.Workspace)\nuget'
-#            outPathRoot: '$(Pipeline.Workspace)\nuget'
-#        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-#          displayName: 'Push to Nuget.org'
-#          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
-#          inputs:
-#            command: 'push'
-#            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
-#            nuGetFeedType: 'external'
-#            publishFeedCredentials: '$(NugetFeedId)'
+        - script: echo Downloading Nuget Artifacts
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: 'NugetPackage'
+            buildType: 'current'
+            targetPath: '$(Pipeline.Workspace)\nuget'
+        - task: PkgESCodeSign@10
+          displayName: 'CodeSign NuGet Package - ''SigningBranch'' only'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          inputs:
+            signConfigXml: '$(Build.SourcesDirectory)\Tools\Nuget.SignConfig.xml'
+            signTimeOut: 360
+            inPathRoot: '$(Pipeline.Workspace)\nuget'
+            outPathRoot: '$(Pipeline.Workspace)\nuget'
+        - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+          displayName: 'Push to Nuget.org'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+          inputs:
+            command: 'push'
+            packagesToPush: '$(Pipeline.Workspace)/nuget/**/*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: '$(NugetFeedId)'
 


### PR DESCRIPTION
I missed the artifact folder name when specifying path to .npmrc. "dry-run" did not catch it but publishing from master didn't work because it defaulted to npmjs registry.