### PR TITLE
Try different SC and fix script break

### DIFF
--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -79,6 +79,7 @@ jobs:
       workingFile: Source\Plugins\IsacPluginGenerator\Assets\Microsoft.SpatialAudio.Spatializer.Unity\.npmrc
   - script: python tools\upm_package.py -s $(Pipeline.Workspace) -o "$(Pipeline.Workspace)\npm" -v $(ProductVersion) -p
     displayName: Publish NPM Package to Internal Feed
+    condition: and(succeeded(), or (eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'), eq(variables['PublishInternal'], 'True')))
   - task: CmdLine@2
     displayName: Copy .npmrc for Public Feed
     inputs:

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -26,7 +26,7 @@ jobs:
           displayName: Public NPM Feed Authentication
           inputs:
             workingFile: '$(Pipeline.Workspace)\NpmPackage\.npmrc'
-            customEndpoint: 'AIPMR SC MixedReality-Unity-Packages'
+            customEndpoint: 'aipmr MixedReality-Unity-Packages'
         - script: npm publish $(Pipeline.Workspace)\NpmPackage
           displayName: Publish NPM Package to Public UPM Feed
 

--- a/Tools/upm_package.py
+++ b/Tools/upm_package.py
@@ -46,7 +46,9 @@ def main():
         result = subprocess.run(["cmd", "/c", "npm version", args.version, "--allow-same-version"], cwd=unity_project_full_path)
         local_copy = False
         if args.publish:
-            npm_command = ["cmd", "/c", "npm publish", "--dry-run" if args.dryrun else ""]
+            npm_command = ["cmd", "/c", "npm publish"]
+            if args.dryrun:
+                npm_command.append("--dry-run")                
         else:
             local_copy = True
             npm_command = ["cmd", "/c", "npm pack"]
@@ -70,7 +72,10 @@ def main():
         if not os.path.exists(args.tarball):
             print("Can't find tarball " + args.tarball)
             exit
-        npm_command = ["cmd", "/c", "npm publish", args.tarball, "--dry-run" if args.dryrun else ""]
+        npm_command = ["cmd", "/c", "npm publish", args.tarball]
+        if args.dryrun:
+            npm_command.append("--dry-run")
+            
         print(npm_command)
         result = subprocess.run(npm_command)
         if (result.returncode != 0):


### PR DESCRIPTION
npm publish is still failing in master with the current SC under a system account. Switching to the SC that's known to work. Internal feed publishing was also inadvertently broken while adding dry-run support, this fixes it. 