### PR TITLE
Signing requires PackageES pool

### DIFF
--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -7,7 +7,7 @@ jobs:
   continueOnError: false
   displayName: Publish Packages to Feeds
   pool:
-    name: Analog On-Prem
+    name: Package ES Lab E
   environment: 'SpatialAudio-Unity Release Approval'
   strategy:
     runOnce:


### PR DESCRIPTION
Nuget package signing auth is failing on analog on-prem pool, I think this requires packagep-es pool.