### PR TITLE
Guard device change and prevent underflow when dropping samples

### DIFF
--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -9,7 +9,7 @@ jobs:
   displayName: Generate Unity and NPM Packages
   pool:
     name: Analog On-Prem
-    demands: Unity2019.4.8f1
+    demands: Unity2019LTS
   variables:
     unityLocation: ''
   steps:

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -25,7 +25,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script:
-        $info = (Get-UnitySetupInstance | Select-UnitySetupInstance -Version $(UnityVersion)).Path + "\Editor";
+        $info = (Get-UnitySetupInstance | Select-UnitySetupInstance -Version $(Unity2019LTSver)).Path + "\Editor";
         Write-Output "##vso[task.setvariable variable=unityLocation;]$info"
   - task: PowerShell@2
     name: SetVersionTag

--- a/Pipelines/Templates/Publish.yaml
+++ b/Pipelines/Templates/Publish.yaml
@@ -7,7 +7,7 @@ jobs:
   continueOnError: false
   displayName: Publish Packages to Feeds
   pool:
-    name: Package ES Lab E
+    name: Analog-1ES-WindowsLatest
   environment: 'SpatialAudio-Unity Release Approval'
   strategy:
     runOnce:

--- a/Pipelines/Templates/Sign.yaml
+++ b/Pipelines/Templates/Sign.yaml
@@ -20,7 +20,7 @@ jobs:
   dependsOn: Consolidate_Artifacts
   continueOnError: false
   pool:
-    name: Package ES Lab E
+    name: Analog-1ES-WindowsLatest
   displayName: Signing Binaries
   steps:
   - script: echo Syncing Source

--- a/Pipelines/Templates/Sign.yaml
+++ b/Pipelines/Templates/Sign.yaml
@@ -4,6 +4,8 @@
 jobs:
 - job: Consolidate_Artifacts
   continueOnError: false
+  pool:
+    name: Analog-1ES-WindowsLatest
   steps:
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/Source/Spatializer/HoloLens2/CircularBuffer.cpp
+++ b/Source/Spatializer/HoloLens2/CircularBuffer.cpp
@@ -118,18 +118,27 @@ void CircularBuffer::WriteSamples(float* sourceBuffer, uint32_t samplesToWrite, 
 
 void CircularBuffer::DropSamples(uint32_t samplesToDrop)
 {
-    // Can we skip samples in one or two parts?
-    if (m_ReadPos + samplesToDrop < m_BufferSize)
+    if (samplesToDrop > m_BufferedSamples)
     {
-        m_ReadPos += samplesToDrop;
+        m_BufferedSamples = 0;
+        m_ReadPos = 0;
+        m_WritePos = 0;
     }
     else
     {
-        uint32_t remainingSamplesToRead = samplesToDrop - (m_BufferSize - m_ReadPos);
-        m_ReadPos = remainingSamplesToRead;
-    }
+        // Can we skip samples in one or two parts?
+        if (m_ReadPos + samplesToDrop < m_BufferSize)
+        {
+            m_ReadPos += samplesToDrop;
+        }
+        else
+        {
+            uint32_t remainingSamplesToRead = samplesToDrop - (m_BufferSize - m_ReadPos);
+            m_ReadPos = remainingSamplesToRead;
+        }
 
-    m_BufferedSamples -= samplesToDrop;
+        m_BufferedSamples -= samplesToDrop;
+    }
 }
 
 uint32_t CircularBuffer::BufferedFrames()

--- a/Source/Spatializer/HoloLens2/CircularBuffer.h
+++ b/Source/Spatializer/HoloLens2/CircularBuffer.h
@@ -28,7 +28,7 @@ private:
     std::unique_ptr<float[], AlignedStore::AlignedFree> m_AudioData;
     uint32_t m_ReadPos;
     uint32_t m_WritePos;
-    uint32_t m_BufferedSamples;
+    std::atomic<uint32_t> m_BufferedSamples;
     uint32_t m_BufferSize;
     uint32_t m_Channels;
 };

--- a/Source/Spatializer/HoloLens2/IsacAdapter.h
+++ b/Source/Spatializer/HoloLens2/IsacAdapter.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <mfapi.h>
 #include <mmdeviceapi.h>
+#include <mutex>
 #include <SpatialAudioClient.h>
 #include <wil/resource.h>
 #include <winrt/Windows.Media.Devices.h>
@@ -47,6 +48,7 @@ private:
     bool m_IsActivated;
     uint32_t m_IsacEventsSinceLastUnityTick;
     winrt::event_token m_DeviceChangeToken;
+    std::mutex m_DeviceChangeLock;
     Microsoft::WRL::ComPtr<IRtwqInterop> m_RtwqInterop;
 };
 


### PR DESCRIPTION
This change should fix issue #55. This crash seems to be from an underflow due to a race between the rendering thread and device change callback which leads to DropSamples changing the read position while the spatializer is in the middle of reading from CircularBuffer. I couldn't get a repro but was able to extract enough information from some of the dumps.   