### PR TITLE
Conditionally sign bins

### DIFF
--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -12,10 +12,10 @@ jobs:
     demands: Unity2020LTS
   variables:
     unityLocation: ''
-    ${{ if ne(variables['Build.SourceBranchName'], variables['SigningBranch']) }}:
-      PackageVersion: '$(ProductVersion)-prerelease.$(Build.SourceBranchName).$(Build.BuildNumber)'
     ${{ if eq(variables['Build.SourceBranchName'], variables['SigningBranch']) }}:
       PackageVersion: $(ProductVersion)
+    ${{ else }}:
+      PackageVersion: '$(ProductVersion)-prerelease.$(Build.SourceBranchName).$(Build.BuildNumber)'
       
   steps:
   - script: echo Downloading Pipeline Artifacts

--- a/Pipelines/Templates/Package.yaml
+++ b/Pipelines/Templates/Package.yaml
@@ -12,7 +12,8 @@ jobs:
     demands: Unity2020LTS
   variables:
     unityLocation: ''
-    PackageVersion: '$(ProductVersion)-prerelease.$(Build.SourceBranchName).$(Build.BuildNumber)'
+    ${{ if ne(variables['Build.SourceBranchName'], variables['SigningBranch']) }}:
+      PackageVersion: '$(ProductVersion)-prerelease.$(Build.SourceBranchName).$(Build.BuildNumber)'
     ${{ if eq(variables['Build.SourceBranchName'], variables['SigningBranch']) }}:
       PackageVersion: $(ProductVersion)
       

--- a/Pipelines/Templates/Sign.yaml
+++ b/Pipelines/Templates/Sign.yaml
@@ -18,7 +18,7 @@ jobs:
       ArtifactName: 'BuildArtifacts'
 
 - job: CodeSign_Binaries
-  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['SigningBranch']))
+  condition: and(succeeded(), or(eq(variables['SignBinaries'], 'true'), eq(variables['Build.SourceBranchName'], variables['SigningBranch'])))
   dependsOn: Consolidate_Artifacts
   continueOnError: false
   pool:
@@ -41,7 +41,7 @@ jobs:
       verbosity: 'Verbose'
       alertWarningLevel: 'High'
   - task: EsrpCodeSigning@1
-    displayName: 'CodeSign Binaries - ''SigningBranch'' only'
+    displayName: 'CodeSign Binaries'
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:


### PR DESCRIPTION
- Sign binaries based on a var
- Use {{ else }} clause for setting PackageVersion. Not sure why earlier builds didn't complain but apparently previous syntax where PackageVersion definition is overridden is not a valid and causes parsing error.  