### PR TITLE
Fix metadata and pickup updated vectormath headers.

### DIFF
--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/Android/libs/arm64-v8a/libAudioPluginMicrosoftSpatializerCrossPlatform.so.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/Android/libs/arm64-v8a/libAudioPluginMicrosoftSpatializerCrossPlatform.so.meta
@@ -71,7 +71,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: X86
+        CPU: ARM
         DontProcess: false
         PlaceholderPath: 
         SDK: AnySDK

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/Android/libs/arm64-v8a/libHrtfDsp.so.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/Android/libs/arm64-v8a/libHrtfDsp.so.meta
@@ -16,7 +16,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 1
+        Exclude Android: 0
         Exclude Editor: 1
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
@@ -26,9 +26,9 @@ PluginImporter:
   - first:
       Android: Android
     second:
-      enabled: 0
+      enabled: 1
       settings:
-        CPU: ARMv7
+        CPU: ARM64
   - first:
       Any: 
     second:

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/Android/libs/armeabi-v7a/libHrtfDsp.so.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/Android/libs/armeabi-v7a/libHrtfDsp.so.meta
@@ -16,7 +16,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 1
+        Exclude Android: 0
         Exclude Editor: 1
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
@@ -26,7 +26,7 @@ PluginImporter:
   - first:
       Android: Android
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: ARMv7
   - first:

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/ARM/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/ARM/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
@@ -75,7 +75,7 @@ PluginImporter:
         DontProcess: false
         PlaceholderPath: 
         SDK: AnySDK
-        ScriptingBackend: Il2Cpp
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/ARM/HrtfDsp.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/ARM/HrtfDsp.dll.meta
@@ -22,7 +22,7 @@ PluginImporter:
         Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
-        Exclude WindowsStoreApps: 1
+        Exclude WindowsStoreApps: 0
   - first:
       Android: Android
     second:
@@ -69,9 +69,9 @@ PluginImporter:
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
-      enabled: 0
+      enabled: 1
       settings:
-        CPU: AnyCPU
+        CPU: ARM
         DontProcess: false
         PlaceholderPath: 
         SDK: AnySDK

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/ARM64/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/ARM64/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
@@ -75,7 +75,7 @@ PluginImporter:
         DontProcess: false
         PlaceholderPath: 
         SDK: AnySDK
-        ScriptingBackend: Il2Cpp
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/ARM64/HrtfDsp.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/ARM64/HrtfDsp.dll.meta
@@ -22,7 +22,7 @@ PluginImporter:
         Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
-        Exclude WindowsStoreApps: 1
+        Exclude WindowsStoreApps: 0
   - first:
       Android: Android
     second:
@@ -69,9 +69,9 @@ PluginImporter:
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
-      enabled: 0
+      enabled: 1
       settings:
-        CPU: X86
+        CPU: ARM64
         DontProcess: false
         PlaceholderPath: 
         SDK: AnySDK

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/x86/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/x86/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
@@ -75,7 +75,7 @@ PluginImporter:
         DontProcess: false
         PlaceholderPath: 
         SDK: AnySDK
-        ScriptingBackend: Il2Cpp
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/x86/HrtfDsp.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/x86/HrtfDsp.dll.meta
@@ -22,7 +22,7 @@ PluginImporter:
         Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
-        Exclude WindowsStoreApps: 1
+        Exclude WindowsStoreApps: 0
   - first:
       Android: Android
     second:
@@ -69,7 +69,7 @@ PluginImporter:
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: X86
         DontProcess: false

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/x86_64/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/x86_64/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
@@ -75,7 +75,7 @@ PluginImporter:
         DontProcess: false
         PlaceholderPath: 
         SDK: AnySDK
-        ScriptingBackend: Il2Cpp
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/x86_64/HrtfDsp.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/WSA/x86_64/HrtfDsp.dll.meta
@@ -22,7 +22,7 @@ PluginImporter:
         Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
-        Exclude WindowsStoreApps: 1
+        Exclude WindowsStoreApps: 0
   - first:
       Android: Android
     second:
@@ -69,9 +69,9 @@ PluginImporter:
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
-      enabled: 0
+      enabled: 1
       settings:
-        CPU: X86
+        CPU: X64
         DontProcess: false
         PlaceholderPath: 
         SDK: AnySDK

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/x86/HrtfDsp.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/x86/HrtfDsp.dll.meta
@@ -18,10 +18,10 @@ PluginImporter:
       settings:
         Exclude Android: 1
         Exclude Editor: 1
-        Exclude Linux64: 1
-        Exclude OSXUniversal: 1
-        Exclude Win: 1
-        Exclude Win64: 1
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
         Exclude WindowsStoreApps: 1
   - first:
       Android: Android
@@ -45,25 +45,25 @@ PluginImporter:
   - first:
       Standalone: Linux64
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: x86
   - first:
       Standalone: Win
     second:
-      enabled: 0
+      enabled: 1
       settings:
-        CPU: None
+        CPU: x86
   - first:
       Standalone: Win64
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: None
   - first:

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/x86_64/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/x86_64/AudioPluginMicrosoftSpatializerCrossPlatform.dll.meta
@@ -41,7 +41,7 @@ PluginImporter:
       settings:
         CPU: x86_64
         DefaultValueInitialized: true
-        OS: AnyOS
+        OS: Windows
   - first:
       Standalone: Linux64
     second:

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/x86_64/HrtfDsp.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/x86_64/HrtfDsp.dll.meta
@@ -17,11 +17,11 @@ PluginImporter:
       enabled: 0
       settings:
         Exclude Android: 1
-        Exclude Editor: 1
-        Exclude Linux64: 1
-        Exclude OSXUniversal: 1
-        Exclude Win: 1
-        Exclude Win64: 1
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
         Exclude WindowsStoreApps: 1
   - first:
       Android: Android
@@ -37,33 +37,33 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: x86_64
         DefaultValueInitialized: true
-        OS: AnyOS
+        OS: Windows
   - first:
       Standalone: Linux64
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: x86_64
   - first:
       Standalone: Win
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: None
   - first:
       Standalone: Win64
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: None
   - first:

--- a/Source/Spatializer/HrtfWrapper.cpp
+++ b/Source/Spatializer/HrtfWrapper.cpp
@@ -82,7 +82,7 @@ HrtfWrapper::HrtfWrapper()
         m_AvailableProcessingSlots.push(static_cast<unsigned char>(c_HrtfMaxSources - i - 1));
     }
 
-    if (!HrtfEngineInitialize(c_HrtfMaxSources, HrtfEngineType_FlexBinaural_High, c_HrtfFrameCount, &m_FlexEngine))
+    if (!HrtfEngineInitialize(c_HrtfMaxSources, HrtfEngineType_FlexBinaural_High_NoReverb, c_HrtfFrameCount, &m_FlexEngine))
     {
         throw std::bad_alloc();
     } 

--- a/Source/Spatializer/SpatializerMixerPlugin.cpp
+++ b/Source/Spatializer/SpatializerMixerPlugin.cpp
@@ -4,7 +4,7 @@
 
 #include "AudioPluginUtil.h"
 #include "HrtfWrapper.h"
-#include "VectorMath.h"
+#include "vectormath.h"
 #include "mathutility.h"
 
 #include <cstring>

--- a/Source/Spatializer/SpatializerPlugin.cpp
+++ b/Source/Spatializer/SpatializerPlugin.cpp
@@ -4,7 +4,7 @@
 
 #include "AudioPluginUtil.h"
 #include "HrtfWrapper.h"
-#include "VectorMath.h"
+#include "vectormath.h"
 #include "mathutility.h"
 
 #include <math.h>

--- a/Source/Utilities/vectormath/test/vectormath_tests.cpp
+++ b/Source/Utilities/vectormath/test/vectormath_tests.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "gtest.h"
-#include "VectorMath.h"
+#include "vectormath.h"
 #include "vectormath_generic.h"
 #include "vectormath_test_data.h"
 #include "cputype.h"

--- a/Source/Utilities/vectormath/vectormath_generic.cpp
+++ b/Source/Utilities/vectormath/vectormath_generic.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "VectorMath.h"
+#include "vectormath.h"
 #include "vectormath_generic.h"
 #include <cstring>
 #include <cmath>
@@ -48,6 +48,172 @@ namespace VectorMath
         return Nlog;
     }
 
+    void FftBitreverse(const floatFC* S, floatFC* X, unsigned int N, const int* bitidx)
+    {
+        // Reorder according to bit reverse involution
+        for (auto i = 0u; i < N; i++)
+        {
+            X[i].re = S[bitidx[i]].re;
+            X[i].im = S[bitidx[i]].im;
+        }
+    }
+
+    void FftBitreverseReal(const float* S, floatFC* X, unsigned int order, const int* bitidx)
+    {
+        // Reorder according to bit reverse involution
+        for (auto i = 0u; i < order; i++)
+        {
+            X[i].re = S[bitidx[i]];
+            X[i].im = 0.0f;
+        }
+    }
+
+    // In-place complex FFT
+    // Warning: Extremely poor performance. This placeholder implementation in FftCore() is here
+    // only as a fallback when porting to new architectures. Targeted instruction set architectures
+    // should be provided with an architecture-specific implementation.
+    void FftCore(floatFC* X, const floatFC* wn, int orderLog)
+    {
+        auto order = 1u << orderLog;
+
+        // 1st buterfly - no multiplication
+        for (auto k = 0u; k < order - 1; k += 2)
+        {
+            auto r = X[k + 1];
+            X[k + 1] = X[k] - r;
+            X[k] = X[k] + r;
+        }
+
+        // Next radix 2 butterflies
+        for (auto i = 1; i < orderLog; i++)
+        {
+            auto m = 1 << (orderLog - 1 - i); // number of butterflies for each Wn value
+            auto sm = 1 << i;                 // Butterfly width / or number of unique Wn
+            for (auto j = 0; j < sm; j++)
+            {
+                auto i1 = j;
+                auto i2 = j + sm;
+                auto n = (j * m) % order;
+                for (auto k = 0; k < m; k++)
+                {
+                    auto r = wn[n] * X[i2];
+                    X[i2] = X[i1] - r;
+                    X[i1] = X[i1] + r;
+                    i1 += 2 * sm;
+                    i2 += 2 * sm;
+                }
+            }
+        }
+    }
+
+    RealFft_generic::RealFft_generic(unsigned int order)
+        : m_Order(order)
+        , m_OrderLog(0u)
+        , m_Wn(order)
+        , m_WnInv(order)
+        , m_TimeResult(order)
+        , m_FreqResult(order)
+        , m_Bitidx(order)
+    {
+        // Order should be positive power of 2
+        auto orderLog = Logi2(order);
+        m_OrderLog = orderLog;
+
+        // Populate wn
+        for (auto i = 0u; i < order; i++)
+        {
+            auto index = static_cast<float>(i);
+            m_Wn[i].re = std::cos(2.0f * c_Pi * index / static_cast<float>(order));
+            m_Wn[i].im = -std::sin(2.0f * c_Pi * index / static_cast<float>(order));
+            m_WnInv[i].re = m_Wn[i].re;
+            m_WnInv[i].im = -m_Wn[i].im;
+        }
+
+        // Populate bitreverse indexes
+        for (auto i = 0u; i < order; i++)
+        {
+            auto k = 0u;
+            for (auto j = 0u; j < orderLog; j++)
+            {
+                auto i1 = 1 << j;
+                auto i2 = 1 << (orderLog - 1 - j);
+                if (i & i1)
+                {
+                    k |= i2;
+                }
+                else
+                {
+                    k &= (~i2);
+                }
+            }
+            m_Bitidx[i] = k;
+        }
+    }
+
+    RealFft_generic::~RealFft_generic()
+    {
+    }
+
+    void RealFft_generic::ForwardFft(
+        const float* timeDomainBuffer, size_t timeDomainLen, floatFC* freqDomainBuffer, size_t freqDomainLen) const
+    {
+        if (freqDomainLen != (m_Order / 2 + 1) || timeDomainLen != m_Order)
+        {
+            throw std::invalid_argument(nullptr);
+        }
+
+        // Bit reverse real
+        FftBitreverseReal(timeDomainBuffer, m_FreqResult.data(), m_Order, m_Bitidx.data());
+
+        // Butterflies
+        FftCore(m_FreqResult.data(), m_Wn.data(), m_OrderLog);
+
+        // Copy non-redundant part of result to output
+        memcpy(freqDomainBuffer, m_FreqResult.data(), this->GetFreqDomainBufferLength() * sizeof(floatFC));
+    }
+
+    void RealFft_generic::InverseFft(
+        const floatFC* freqDomainBuffer, size_t freqDomainLen, float* timeDomainBuffer, size_t timeDomainLen) const
+    {
+        if (freqDomainLen != (m_Order / 2 + 1) || timeDomainLen != m_Order)
+        {
+            throw std::invalid_argument(nullptr);
+        }
+
+        // Copy to work area and extend redundant frequencies
+        memcpy(m_FreqResult.data(), freqDomainBuffer, freqDomainLen * sizeof(floatFC));
+        auto j = 2u;
+        for (auto i = this->GetFreqDomainBufferLength(); i < m_Order; i++)
+        {
+            m_FreqResult[i] = ComplexConjugate(m_FreqResult[i - j]);
+            j += 2;
+        }
+
+        // Bit reverse
+        FftBitreverse(m_FreqResult.data(), m_TimeResult.data(), m_Order, m_Bitidx.data());
+
+        // Butterflies
+        FftCore(m_TimeResult.data(), m_WnInv.data(), m_OrderLog);
+
+        // Scale and copy to output
+        for (auto i = 0u; i < m_Order; i++)
+        {
+            timeDomainBuffer[i] = m_TimeResult[i].re / m_Order;
+        }
+    }
+
+    unsigned int RealFft_generic::GetFreqDomainBufferLength() const noexcept
+    {
+        // Careful about 'simplifying' this, the operation takes advantage of
+        // integer rounding in the divide
+        return (m_Order / 2 + 1);
+    }
+
+    uint32_t RealFft_generic::GetTimeDomainBufferLength() const noexcept
+    {
+        return m_Order;
+    }
+
     namespace Arithmetic_Generic
     {
         void Add_32f(float* pDst, const float* pSrc1, const float* pSrc2, size_t const length)
@@ -57,6 +223,16 @@ namespace VectorMath
             for (i = 0; i < length; i += 1)
             {
                 pDst[i] = pSrc1[i] + pSrc2[i];
+            }
+        }
+
+        void Add_32f(float* pDst, const float* pSrc1, const float* pSrc2, const float* pSrc3, size_t const length)
+        {
+            size_t i;
+
+            for (i = 0; i < length; i += 1)
+            {
+                pDst[i] = pSrc1[i] + pSrc2[i] + pSrc3[i];
             }
         }
 
@@ -72,6 +248,26 @@ namespace VectorMath
                 reinterpret_cast<const float*>(pSrc1),
                 reinterpret_cast<const float*>(pSrc2),
                 length * 2);
+        }
+
+        void Sub_32f(float* pDst, const float* pSrc1, const float* pSrc2, size_t const length)
+        {
+            size_t i;
+
+            for (i = 0; i < length; i += 1)
+            {
+                pDst[i] = pSrc1[i] - pSrc2[i];
+            }
+        }
+
+        void Sub_32fc(floatFC* pDst, const floatFC* pSrc1, const floatFC* pSrc2, size_t const length)
+        {
+            size_t i;
+
+            for (i = 0; i < length; i += 1)
+            {
+                pDst[i] = pSrc1[i] - pSrc2[i];
+            }
         }
 
         /* The implementations of the below functions were taken from
@@ -174,6 +370,67 @@ namespace VectorMath
             }
 
             *pDst = dst;
+        }
+
+        _Use_decl_annotations_ void DotProdC_32f(
+            float* pDst, float const* pSrc1, float const* pSrc2, float const* pSrc3, float const val1, float const val2,
+            float const val3, size_t length)
+        {
+            size_t i;
+
+            for (i = 0; i < length; i++)
+            {
+                pDst[i] = (pSrc1[i] * val1) + (pSrc2[i] * val2) + (pSrc3[i] * val3);
+            }
+        }
+
+        _Use_decl_annotations_ uint32_t FindMaxIndex_32f(_In_ float* pVec, _In_ size_t const length)
+        {
+            if (length == 0)
+            {
+                return 0;
+            }
+
+            size_t i;
+            float maxValue = pVec[0];
+            size_t maxIndex = 0;
+
+            for (i = 1; i < length; i += 1)
+            {
+                if (pVec[i] >= maxValue)
+                {
+                    maxValue = pVec[i];
+                    maxIndex = i;
+                }
+            }
+
+            return static_cast<uint32_t>(maxIndex);
+        }
+
+        // result = a * (1 - remainder) + b * (remainder);
+        // Or factor out remainder: result = a + (remainder * (b - a));
+        _Use_decl_annotations_ void
+        Interpolate_32f(float* pDst, const float* pSrcA, float const* pSrcB, const float* pSrcR, size_t length)
+        {
+            size_t i = 0;
+
+            for (i = 0; i < length; i++)
+            {
+                pDst[i] = pSrcA[i] + (pSrcR[i] * (pSrcB[i] - pSrcA[i]));
+            }
+        }
+
+        // result = a * (1 - remainder) + b * (remainder);
+        // Or factor out remainder: result = a + (remainder * (b - a));
+        _Use_decl_annotations_ void
+        InterpolateC_32f(float* pDst, const float* pSrcA, float const* pSrcB, const float remainder, size_t length)
+        {
+            size_t i = 0;
+
+            for (i = 0; i < length; i++)
+            {
+                pDst[i] = pSrcA[i] + (remainder * (pSrcB[i] - pSrcA[i]));
+            }
         }
     } // namespace Arithmetic_Generic
 } // namespace VectorMath

--- a/Source/Utilities/vectormath/vectormath_generic.h
+++ b/Source/Utilities/vectormath/vectormath_generic.h
@@ -1,18 +1,52 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 #pragma once
 
 namespace VectorMath
 {
+
+    // Standard C++ implementation of a Fast Fourier Transform (FFT) for real-valued data
+    class RealFft_generic : public IRealFft
+    {
+    public:
+        RealFft_generic(unsigned int order);
+        virtual ~RealFft_generic();
+
+        virtual void ForwardFft(
+            const float* timeDomainBuffer, size_t timeDomainLen, floatFC* freqDomainBuffer,
+            size_t freqDomainLen) const override;
+
+        virtual void InverseFft(
+            const floatFC* freqDomainBuffer, size_t freqDomainLen, float* timeDomainBuffer,
+            size_t timeDomainLen) const override;
+
+        virtual unsigned int GetFreqDomainBufferLength() const noexcept override;
+        virtual uint32_t GetTimeDomainBufferLength() const noexcept override;
+
+    private:
+        uint32_t m_Order;
+        uint32_t m_OrderLog;
+        mutable std::vector<floatFC> m_Wn;
+        mutable std::vector<floatFC> m_WnInv;
+        mutable std::vector<floatFC> m_TimeResult;
+        mutable std::vector<floatFC> m_FreqResult;
+        mutable std::vector<int> m_Bitidx;
+    };
+
     // Standard C++ implementation of the vector math operations
     namespace Arithmetic_Generic
     {
         void Add_32f(float* pDst, float const* pSrc1, float const* pSrc2, size_t const length);
 
+        void Add_32f(float* pDst, float const* pSrc1, float const* pSrc2, float const* pSrc3, size_t const length);
+
         void Add_32f_I(float* pSrcDst, float const* pSrc, size_t const length);
 
         void Add_32fc(floatFC* pDst, floatFC const* pSrc1, floatFC const* pSrc2, size_t const length);
+
+        void Sub_32f(float* pDst, float const* pSrc1, float const* pSrc2, size_t const length);
+
+        void Sub_32fc(floatFC* pDst, floatFC const* pSrc1, floatFC const* pSrc2, size_t const length);
 
         void Mul_32fc(
             _Out_writes_(length) floatFC* pDst, _In_reads_(length) floatFC const* pSrc1,
@@ -41,6 +75,21 @@ namespace VectorMath
         void DotProd_32f(
             _Out_writes_(1) float* pDst, _In_reads_(length) float const* pSrc1, _In_reads_(length) float const* pSrc2,
             _In_ size_t const length);
-    }
+
+        void DotProdC_32f(
+            _Out_writes_(length) float* pDst, _In_reads_(length) float const* pSrc1,
+            _In_reads_(length) float const* pSrc2, _In_reads_(length) float const* pSrc3, _In_ float const val1,
+            _In_ float const val2, _In_ float const val3, _In_ size_t length);
+
+        uint32_t FindMaxIndex_32f(_In_ float* pVec, _In_ size_t const length);
+
+        void Interpolate_32f(
+            _Inout_updates_(length) float* pDst, _In_reads_(length) const float* pSrcA,
+            _In_reads_(length) float const* pSrcB, _In_reads_(length) const float* pSrcR, size_t length);
+
+        void InterpolateC_32f(
+            _Inout_updates_(length) float* pDst, _In_reads_(length) const float* pSrcA,
+            _In_reads_(length) float const* pSrcB, _In_ const float remainder, size_t length);
+    } // namespace Arithmetic_Generic
 
 } // namespace VectorMath

--- a/Source/Utilities/vectormath/vectormath_neon.cpp
+++ b/Source/Utilities/vectormath/vectormath_neon.cpp
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 #include "cputype.h"
-
 #if defined(ARCH_ARM) || defined(ARCH_ARM64)
-#include "VectorMath.h"
+
+#include "vectormath.h"
 #include "vectormath_neon.h"
 // For the unaligned portions, some functions fall back to the generic impl
 #include "vectormath_generic.h"
@@ -60,6 +60,25 @@ namespace VectorMath
             }
         }
 
+        void Add_32f(float* pDst, const float* pSrc1, const float* pSrc2, const float* pSrc3, size_t const length)
+        {
+            auto i = 0u;
+            for (; i + 4 <= length; i += 4)
+            {
+                auto src1 = vld1q_f32(pSrc1 + i);
+                auto src2 = vld1q_f32(pSrc2 + i);
+                auto src3 = vld1q_f32(pSrc3 + i);
+                auto temp = vaddq_f32(src1, src2);
+                auto dst = vaddq_f32(temp, src3);
+                vst1q_f32(pDst + i, dst);
+            }
+
+            if (i < length)
+            {
+                Arithmetic_Generic::Add_32f(pDst + i, pSrc1 + i, pSrc2 + i, pSrc3 + i, length - i);
+            }
+        }
+
         void Add_32f_I(float* pSrcDst, const float* pSrc, size_t length)
         {
             Add_32f(pSrcDst, pSrcDst, pSrc, length);
@@ -72,6 +91,28 @@ namespace VectorMath
                 reinterpret_cast<const float*>(pSrc1),
                 reinterpret_cast<const float*>(pSrc2),
                 length * 2);
+        }
+
+        void Sub_32f(float* pDst, const float* pSrc1, const float* pSrc2, size_t const length)
+        {
+            auto i = 0u;
+            for (; i + 4 <= length; i += 4)
+            {
+                auto src1 = vld1q_f32(pSrc1 + i);
+                auto src2 = vld1q_f32(pSrc2 + i);
+                auto dst = vsubq_f32(src1, src2);
+                vst1q_f32(pDst + i, dst);
+            }
+
+            if (i < length)
+            {
+                Arithmetic_Generic::Sub_32f(pDst + i, pSrc1 + i, pSrc2 + i, length - i);
+            }
+        }
+
+        void Sub_32fc(floatFC* pDst, const floatFC* pSrc1, const floatFC* pSrc2, const size_t length)
+        {
+            Sub_32f((float*) pDst, (float const*) pSrc1, (float const*) pSrc2, length * 2);
         }
 
         _Use_decl_annotations_ void
@@ -146,7 +187,7 @@ namespace VectorMath
                 auto src1 = vld1q_f32(pSrc1 + i);
                 auto src2 = vld1q_f32(pSrc2 + i);
                 auto srcDst = vld1q_f32(pSrcDst + i);
-                srcDst = vmlaq_f32(src1, src2, srcDst);
+                srcDst = vmlaq_f32(srcDst, src1, src2);
                 vst1q_f32(pSrcDst + i, srcDst);
             }
 
@@ -219,6 +260,136 @@ namespace VectorMath
             // Horizontal sum
             auto resultPair = vadd_f32(vget_high_f32(sum), vget_low_f32(sum));
             *pDst += vget_lane_f32(resultPair, 0) + vget_lane_f32(resultPair, 1);
+        }
+
+        // dst = (src1 * val1) + (src2 * val2) + (src3 * val3)
+        _Use_decl_annotations_ void DotProdC_32f(
+            float* pDst, float const* pSrc1, float const* pSrc2, float const* pSrc3, float const val1, float const val2,
+            float const val3, size_t length)
+        {
+            auto idxMax = length / 4;
+            auto const val1Vec = vmovq_n_f32(val1);
+            auto const val2Vec = vmovq_n_f32(val2);
+            auto const val3Vec = vmovq_n_f32(val3);
+
+            for (size_t i = 0; i < idxMax; i++)
+            {
+                auto src1 = vld1q_f32(pSrc1);
+                auto src2 = vld1q_f32(pSrc2);
+                auto src3 = vld1q_f32(pSrc3);
+                pSrc1 += 4;
+                pSrc2 += 4;
+                pSrc3 += 4;
+
+                auto res1 = vmulq_f32(src1, val1Vec);
+                auto res2 = vmulq_f32(src2, val2Vec);
+                auto res3 = vmulq_f32(src3, val3Vec);
+
+                auto res4 = vaddq_f32(res3, vaddq_f32(res1, res2));
+                vst1q_f32(pDst, res4);
+                pDst += 4;
+            }
+
+            // Deal with remainder
+            for (size_t i = idxMax * 4; i < length; i++)
+            {
+                pDst[i] = (pSrc1[i] * val1) + (pSrc2[i] * val2) + (pSrc3[i] * val3);
+            }
+        }
+
+        // float result = a * (1 - remainder) + b * (remainder);
+        // Or: a + (remainder * (b - a)); // Factor out remainder
+        _Use_decl_annotations_ void Interpolate_32f(
+            _Inout_updates_(length) float* pDst, _In_reads_(length) const float* pSrcA,
+            _In_reads_(length) float const* pSrcB, _In_reads_(length) const float* pSrcR, size_t length)
+        {
+            auto idxMax = length / 4;
+
+            for (size_t i = 0; i < idxMax; i++)
+            {
+                auto a = vld1q_f32(pSrcA);
+                auto b = vld1q_f32(pSrcB);
+                auto remainder = vld1q_f32(pSrcR);
+                auto curDst = vld1q_f32(pDst);
+
+                auto result = vaddq_f32(a, vmulq_f32(remainder, vsubq_f32(b, a)));
+                vst1q_f32(pDst, result);
+
+                pSrcA += 4;
+                pSrcB += 4;
+                pSrcR += 4;
+                pDst += 4;
+            }
+
+            // Finish remainder
+            for (size_t i = idxMax * 4; i < length; i++)
+            {
+                pDst[i] = pSrcA[i] + (pSrcR[i] * (pSrcB[i] - pSrcA[i]));
+            }
+        }
+
+        _Use_decl_annotations_ uint32_t FindMaxIndex_32f(_In_ float* pVec, _In_ size_t const length)
+        {
+            if (length == 0)
+            {
+                return 0;
+            }
+
+            auto idxMax = length / 4;
+
+            uint32_t values[4] = {0, 1, 2, 3};
+            auto indicesVec = vld1q_u32(values);
+            auto maxIndicesVec = indicesVec;
+            auto maxValuesVec = vld1q_f32(pVec);
+            auto incVec = vdupq_n_u32(4);
+
+            for (size_t i = 4; i < length; i += 4)
+            {
+                // Increment the indices
+                indicesVec = vaddq_u32(indicesVec, incVec);
+
+                auto src = vld1q_f32(pVec + i);
+
+                // Get bit result as to which vector had the higher value for each element
+                auto IdxMask = vcgtq_f32(src, maxValuesVec);
+
+                // Using the bitmask, save the index that belongs to the highest value
+                maxIndicesVec = vbslq_u32(IdxMask, indicesVec, maxIndicesVec);
+
+                // Find max values
+                maxValuesVec = vmaxq_f32(maxValuesVec, src);
+            }
+
+            // Get max value/index horizontally
+            auto maxValue = vgetq_lane_f32(maxValuesVec, 0);
+            auto maxIndex = vgetq_lane_u32(maxIndicesVec, 0);
+            if (maxValue < vgetq_lane_f32(maxValuesVec, 1))
+            {
+                maxValue = vgetq_lane_f32(maxValuesVec, 1);
+                maxIndex = vgetq_lane_u32(maxIndicesVec, 1);
+            }
+            if (maxValue < vgetq_lane_f32(maxValuesVec, 2))
+            {
+                maxValue = vgetq_lane_f32(maxValuesVec, 2);
+                maxIndex = vgetq_lane_u32(maxIndicesVec, 2);
+            }
+            if (maxValue < vgetq_lane_f32(maxValuesVec, 3))
+            {
+                maxValue = vgetq_lane_f32(maxValuesVec, 3);
+                maxIndex = vgetq_lane_u32(maxIndicesVec, 3);
+            }
+
+            // Deal with residual
+            for (size_t i = idxMax * 4; i < length; i++)
+            {
+                if (pVec[i] > maxValue)
+                {
+                    maxValue = pVec[i];
+                    maxIndex = static_cast<uint32_t>(i);
+                }
+            }
+
+            return maxIndex;
         }
     } // namespace Arithmetic_Neon
 } // namespace VectorMath

--- a/Source/Utilities/vectormath/vectormath_neon.h
+++ b/Source/Utilities/vectormath/vectormath_neon.h
@@ -13,12 +13,21 @@ namespace VectorMath
         /* Sum two float vectors and store the result vector into the destination vector */
         void Add_32f(float* pDst, float const* pSrc1, float const* pSrc2, size_t const length);
 
+        /* Sum three float vectors and store the result vector into the destination vector */
+        void Add_32f(float* pDst, float const* pSrc1, float const* pSrc2, float const* pSrc3, size_t const length);
+
         /* Add float array to another */
         void Add_32f_I(float* pSrcDst, float const* pSrc, size_t const length);
 
         /* Sum two complex number float vectors and store the result vector into
         the destination vector */
         void Add_32fc(floatFC* pDst, floatFC const* pSrc1, floatFC const* pSrc2, size_t const length);
+
+        /* Subtract two float vectors and store the result vector into the destination vector */
+        void Sub_32f(float* pDst, float const* pSrc1, float const* pSrc2, size_t const length);
+
+        /* Subtract two complex float vectors and store the result vector into the destination vector */
+        void Sub_32fc(floatFC* pDst, floatFC const* pSrc1, floatFC const* pSrc2, size_t const length);
 
         /* multiply 2 arrays of complex floats numbers and save the result into
         the destination vector */
@@ -59,6 +68,20 @@ namespace VectorMath
         void DotProd_32f(
             _Out_writes_(1) float* pDst, _In_reads_(length) float const* pSrc1, _In_reads_(length) float const* pSrc2,
             _In_ size_t const length);
+
+        /* compute dot product of 3 vectors and 3 constants */
+        void DotProdC_32f(
+            _Out_writes_(length) float* pDst, _In_reads_(length) float const* pSrc1,
+            _In_reads_(length) float const* pSrc2, _In_reads_(length) float const* pSrc3, _In_ float const val1,
+            _In_ float const val2, _In_ float const val3, _In_ size_t length);
+
+        /* solve the interpolation equation: result = a + (remainder * (b - a))*/
+        void Interpolate_32f(
+            _Inout_updates_(length) float* pDst, _In_reads_(length) const float* pSrcA,
+            _In_reads_(length) float const* pSrcB, _In_reads_(length) const float* pSrcR, size_t length);
+
+        /* Find index of max element in vector */
+        uint32_t FindMaxIndex_32f(_In_ float* pVec, _In_ size_t const length);
     } // namespace Arithmetic_Neon
 } // namespace VectorMath
 

--- a/Source/Utilities/vectormath/vectormath_sse2.cpp
+++ b/Source/Utilities/vectormath/vectormath_sse2.cpp
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 #include "cputype.h"
 #if defined(ARCH_X86) || defined(ARCH_X64)
-#include "VectorMath.h"
+#include "vectormath.h"
 #include "vectormath_sse2.h"
 #include <cstring>
 #include <cmath>
 // SSE2 header
 #include <xmmintrin.h>
+// SSE4 header
+#include <smmintrin.h>
+#include <algorithm>
 
 namespace VectorMath
 {
@@ -120,7 +122,98 @@ namespace VectorMath
                 pSrc1 += 1;
                 pSrc2 += 1;
                 pDst += 1;
-                i += 1;
+            }
+        }
+
+        void Add_32f(float* pDst, const float* pSrc1, const float* pSrc2, const float* pSrc3, size_t const length)
+        {
+            size_t i;
+
+            // aligned branch. check if pointers can be aligned.
+            if ((0 == (((ptrdiff_t) pDst) & 0x03)) && ((((ptrdiff_t) pDst) & 0x0f) == (((ptrdiff_t) pSrc1 & 0x0f))) &&
+                ((((ptrdiff_t) pDst) & 0x0f) == (((ptrdiff_t) pSrc2 & 0x0f))) &&
+                ((((ptrdiff_t) pDst) & 0x0f) == (((ptrdiff_t) pSrc3 & 0x0f))))
+            {
+                // align the destination
+                i = 0;
+                while ((i < length) && ((ptrdiff_t) pDst & 0x0f))
+                {
+                    *pDst = *pSrc1 + *pSrc2 + *pSrc3;
+                    pSrc1 += 1;
+                    pSrc2 += 1;
+                    pSrc3 += 1;
+                    pDst += 1;
+                    i += 1;
+                }
+
+                // everything is aligned
+                for (; i + 16 <= length; i += 16)
+                {
+                    __m128 xmm0, xmm1, xmm2, xmm3;
+
+                    xmm0 = _mm_load_ps(pSrc1);
+                    xmm1 = _mm_load_ps(pSrc1 + 4);
+                    xmm2 = _mm_load_ps(pSrc1 + 8);
+                    xmm3 = _mm_load_ps(pSrc1 + 12);
+                    pSrc1 += 16;
+                    xmm0 = _mm_add_ps(xmm0, *((__m128*) (pSrc2)));
+                    xmm1 = _mm_add_ps(xmm1, *((__m128*) (pSrc2 + 4)));
+                    xmm2 = _mm_add_ps(xmm2, *((__m128*) (pSrc2 + 8)));
+                    xmm3 = _mm_add_ps(xmm3, *((__m128*) (pSrc2 + 12)));
+                    pSrc2 += 16;
+                    xmm0 = _mm_add_ps(xmm0, *((__m128*) (pSrc3)));
+                    xmm1 = _mm_add_ps(xmm1, *((__m128*) (pSrc3 + 4)));
+                    xmm2 = _mm_add_ps(xmm2, *((__m128*) (pSrc3 + 8)));
+                    xmm3 = _mm_add_ps(xmm3, *((__m128*) (pSrc3 + 12)));
+                    pSrc3 += 16;
+                    _mm_store_ps(pDst, xmm0);
+                    _mm_store_ps(pDst + 4, xmm1);
+                    _mm_store_ps(pDst + 8, xmm2);
+                    _mm_store_ps(pDst + 12, xmm3);
+                    pDst += 16;
+                }
+
+                for (; i + 4 <= length; i += 4)
+                {
+                    __m128 xmm0;
+
+                    xmm0 = _mm_load_ps(pSrc1);
+                    pSrc1 += 4;
+                    xmm0 = _mm_add_ps(xmm0, *((__m128*) (pSrc2)));
+                    pSrc2 += 4;
+                    xmm0 = _mm_add_ps(xmm0, *((__m128*) (pSrc3)));
+                    pSrc3 += 4;
+                    _mm_store_ps(pDst, xmm0);
+                    pDst += 4;
+                }
+            }
+            // unaligned branch
+            else
+            {
+                for (i = 0; i + 4 <= length; i += 4)
+                {
+                    __m128 xmm0, xmm1;
+
+                    xmm1 = _mm_loadu_ps(pSrc1);
+                    pSrc1 += 4;
+                    xmm0 = _mm_loadu_ps(pSrc2);
+                    pSrc2 += 4;
+                    xmm0 = _mm_loadu_ps(pSrc3);
+                    pSrc3 += 4;
+                    xmm0 = _mm_add_ps(xmm0, xmm1);
+                    _mm_storeu_ps(pDst, xmm0);
+                    pDst += 4;
+                }
+            }
+
+            // remain floats
+            for (; i < length; i += 1)
+            {
+                *pDst = *pSrc1 + *pSrc2 + *pSrc3;
+                pSrc1 += 1;
+                pSrc2 += 1;
+                pSrc3 += 1;
+                pDst += 1;
             }
         }
 
@@ -132,6 +225,91 @@ namespace VectorMath
         void Add_32fc(floatFC* pDst, const floatFC* pSrc1, const floatFC* pSrc2, const size_t length)
         {
             Add_32f((float*) pDst, (float const*) pSrc1, (float const*) pSrc2, length * 2);
+        }
+
+        void Sub_32f(float* pDst, const float* pSrc1, const float* pSrc2, size_t const length)
+        {
+            size_t i;
+
+            // aligned branch. check if pointers can be aligned.
+            if ((0 == (((ptrdiff_t) pDst) & 0x03)) && ((((ptrdiff_t) pDst) & 0x0f) == (((ptrdiff_t) pSrc1 & 0x0f))) &&
+                ((((ptrdiff_t) pDst) & 0x0f) == (((ptrdiff_t) pSrc2 & 0x0f))))
+            {
+                // align the destination
+                i = 0;
+                while ((i < length) && ((ptrdiff_t) pDst & 0x0f))
+                {
+                    *pDst = *pSrc1 - *pSrc2;
+                    pSrc1 += 1;
+                    pSrc2 += 1;
+                    pDst += 1;
+                    i += 1;
+                }
+
+                // everything is aligned
+                for (; i + 16 <= length; i += 16)
+                {
+                    __m128 xmm0, xmm1, xmm2, xmm3;
+
+                    xmm0 = _mm_load_ps(pSrc1);
+                    xmm1 = _mm_load_ps(pSrc1 + 4);
+                    xmm2 = _mm_load_ps(pSrc1 + 8);
+                    xmm3 = _mm_load_ps(pSrc1 + 12);
+                    pSrc1 += 16;
+                    xmm0 = _mm_sub_ps(xmm0, *((__m128*) (pSrc2)));
+                    xmm1 = _mm_sub_ps(xmm1, *((__m128*) (pSrc2 + 4)));
+                    xmm2 = _mm_sub_ps(xmm2, *((__m128*) (pSrc2 + 8)));
+                    xmm3 = _mm_sub_ps(xmm3, *((__m128*) (pSrc2 + 12)));
+                    pSrc2 += 16;
+                    _mm_store_ps(pDst, xmm0);
+                    _mm_store_ps(pDst + 4, xmm1);
+                    _mm_store_ps(pDst + 8, xmm2);
+                    _mm_store_ps(pDst + 12, xmm3);
+                    pDst += 16;
+                }
+
+                for (; i + 4 <= length; i += 4)
+                {
+                    __m128 xmm0;
+
+                    xmm0 = _mm_load_ps(pSrc1);
+                    pSrc1 += 4;
+                    xmm0 = _mm_sub_ps(xmm0, *((__m128*) (pSrc2)));
+                    pSrc2 += 4;
+                    _mm_store_ps(pDst, xmm0);
+                    pDst += 4;
+                }
+            }
+            // unaligned branch
+            else
+            {
+                for (i = 0; i + 4 <= length; i += 4)
+                {
+                    __m128 xmm0, xmm1;
+
+                    xmm1 = _mm_loadu_ps(pSrc1);
+                    pSrc1 += 4;
+                    xmm0 = _mm_loadu_ps(pSrc2);
+                    pSrc2 += 4;
+                    xmm0 = _mm_sub_ps(xmm0, xmm1);
+                    _mm_storeu_ps(pDst, xmm0);
+                    pDst += 4;
+                }
+            }
+
+            // remain floats
+            for (; i < length; i += 1)
+            {
+                *pDst = *pSrc1 - *pSrc2;
+                pSrc1 += 1;
+                pSrc2 += 1;
+                pDst += 1;
+            }
+        }
+
+        void Sub_32fc(floatFC* pDst, const floatFC* pSrc1, const floatFC* pSrc2, const size_t length)
+        {
+            Sub_32f((float*) pDst, (float const*) pSrc1, (float const*) pSrc2, length * 2);
         }
 
         /* The implementations of the below functions were taken from
@@ -896,6 +1074,136 @@ namespace VectorMath
 
             // store the result
             _mm_store_ss(pDst, GetSum(sum));
+        }
+
+        // dst = (src1 * val1) + (src2 * val2) + (src3 * val3)
+        _Use_decl_annotations_ void DotProdC_32f(
+            float* pDst, float const* pSrc1, float const* pSrc2, float const* pSrc3, float const val1, float const val2,
+            float const val3, size_t length)
+        {
+            auto idxMax = length / 4;
+            auto const val1Vec = _mm_load_ps1(&val1);
+            auto const val2Vec = _mm_load_ps1(&val2);
+            auto const val3Vec = _mm_load_ps1(&val3);
+
+            for (size_t i = 0; i < idxMax; i++)
+            {
+                auto src1 = _mm_loadu_ps(pSrc1);
+                auto src2 = _mm_loadu_ps(pSrc2);
+                auto src3 = _mm_loadu_ps(pSrc3);
+                pSrc1 += 4;
+                pSrc2 += 4;
+                pSrc3 += 4;
+
+                auto res1 = _mm_mul_ps(src1, val1Vec);
+                auto res2 = _mm_mul_ps(src2, val2Vec);
+                auto res3 = _mm_mul_ps(src3, val3Vec);
+
+                auto res4 = _mm_add_ps(res3, _mm_add_ps(res1, res2));
+                _mm_store_ps(pDst, res4);
+                pDst += 4;
+            }
+
+            for (size_t i = idxMax * 4; i < length; i++)
+            {
+                pDst[i] = (pSrc1[i] * val1) + (pSrc2[i] * val2) + (pSrc3[i] * val3);
+            }
+        }
+
+        // float result = a * (1 - remainder) + b * (remainder);
+        // Or: a + (remainder * (b - a)); // Factor out remainder
+        _Use_decl_annotations_ void Interpolate_32f(
+            _Inout_updates_(length) float* pDst, _In_reads_(length) const float* pSrcA,
+            _In_reads_(length) float const* pSrcB, _In_reads_(length) const float* pSrcR, size_t length)
+        {
+            auto idxMax = length / 4;
+
+            for (size_t i = 0; i < idxMax; i++)
+            {
+                auto a = _mm_loadu_ps(pSrcA + i * 4);
+                auto b = _mm_loadu_ps(pSrcB + i * 4);
+                auto remainder = _mm_loadu_ps(pSrcR + i * 4);
+                auto curDst = _mm_loadu_ps(pDst + i * 4);
+
+                auto result = _mm_add_ps(a, _mm_mul_ps(remainder, _mm_sub_ps(b, a)));
+                _mm_store_ps(pDst + i * 4, result);
+            }
+
+            // Finish remainder
+            for (size_t i = idxMax * 4; i < length; i++)
+            {
+                pDst[i] = pSrcA[i] + (pSrcR[i] * (pSrcB[i] - pSrcA[i]));
+            }
+        }
+
+        /* Find index of max element in vector */
+        _Use_decl_annotations_ uint32_t FindMaxIndex_32f(_In_ float* pSrc, _In_ size_t const length)
+        {
+            if (length == 0)
+            {
+                return 0;
+            }
+            float maxValues[4];
+            float maxIndices[4];
+
+            auto incVec = _mm_set1_ps(4);
+            auto indicesVec = _mm_setr_ps(0, 1, 2, 3);
+            auto maxIndicesVec = indicesVec;
+            auto maxValuesVec = _mm_loadu_ps(pSrc); // Start with 0
+
+            for (size_t i = 4; i < length; i += 4)
+            {
+                // Increment indices
+                indicesVec = _mm_add_ps(indicesVec, incVec);
+
+                auto src = _mm_loadu_ps(pSrc + i);
+
+                // See if we have any new max values
+                auto gt = _mm_cmpgt_ps(src, maxValuesVec);
+
+                // Copy over the indices of new max values
+#ifdef __SSE4_1__ // SSE4 implementation
+                maxIndicesVec = _mm_blendv_ps(maxIndicesVec, indicesVec, gt);
+#else // pre-SSE4 implementation
+                auto maxIndicesMask = _mm_andnot_ps(gt, maxIndicesVec);
+                auto indicesMask = _mm_and_ps(gt, indicesVec);
+                maxIndicesVec = _mm_or_ps(maxIndicesMask, indicesMask);
+#endif
+                // Save the new max values
+                maxValuesVec = _mm_max_ps(src, maxValuesVec);
+            }
+
+            // Find the max in the vectors
+            _mm_storeu_ps(maxValues, maxValuesVec);
+            _mm_storeu_ps(maxIndices, maxIndicesVec);
+
+            // Start with 0
+            auto maxIndex = maxIndices[0];
+            auto maxValue = maxValues[0];
+            for (int i = 1; i < 4; i++)
+            {
+                if (maxValues[i] >= maxValue)
+                {
+                    maxValue = maxValues[i];
+                    maxIndex = maxIndices[i];
+                }
+            }
+
+            // Get the uint version of the float
+            uint32_t finalResult = static_cast<uint32_t>(maxIndex);
+
+            // Deal with residual
+            const uint32_t residualStart = (uint32_t)(length / 4) * 4;
+            for (auto i = residualStart; i < length; i++)
+            {
+                if (pSrc[i] > maxValue)
+                {
+                    maxValue = pSrc[i];
+                    finalResult = i;
+                }
+            }
+
+            return finalResult;
         }
     } // namespace Arithmetic_Sse2
 } // namespace VectorMath

--- a/Source/Utilities/vectormath/vectormath_sse2.h
+++ b/Source/Utilities/vectormath/vectormath_sse2.h
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 #pragma once
 #include "cputype.h"
 #if defined(ARCH_X86) || defined(ARCH_X64)
@@ -12,12 +11,21 @@ namespace VectorMath
         /* Sum two float vectors and store the result vector into the destination vector */
         void Add_32f(float* pDst, float const* pSrc1, float const* pSrc2, size_t const length);
 
+        /* Sum three float vectors and store the result vector into the destination vector */
+        void Add_32f(float* pDst, float const* pSrc1, float const* pSrc2, float const* pSrc3, size_t const length);
+
         /* Add float array to another */
         void Add_32f_I(float* pSrcDst, float const* pSrc, size_t const length);
 
         /* Sum two complex number float vectors and store the result vector into
         the destination vector */
         void Add_32fc(floatFC* pDst, floatFC const* pSrc1, floatFC const* pSrc2, size_t const length);
+
+        /* Subtract two float vectors and store the result vector into the destination vector */
+        void Sub_32f(float* pDst, float const* pSrc1, float const* pSrc2, size_t const length);
+
+        /* Subtract two complex float vectors and store the result vector into the destination vector */
+        void Sub_32fc(floatFC* pDst, floatFC const* pSrc1, floatFC const* pSrc2, size_t const length);
 
         /* multiply 2 arrays of complex floats numbers and save the result into
         the destination vector */
@@ -58,6 +66,20 @@ namespace VectorMath
         void DotProd_32f(
             _Out_writes_(1) float* pDst, _In_reads_(length) float const* pSrc1, _In_reads_(length) float const* pSrc2,
             _In_ size_t const length);
-    }
-}
+
+        /* compute dot product of 3 vectors and 3 constants */
+        void DotProdC_32f(
+            _Out_writes_(length) float* pDst, _In_reads_(length) float const* pSrc1,
+            _In_reads_(length) float const* pSrc2, _In_reads_(length) float const* pSrc3, _In_ float const val1,
+            _In_ float const val2, _In_ float const val3, _In_ size_t length);
+
+        /* solve the interpolation equation: result = a + (remainder * (b - a))*/
+        void Interpolate_32f(
+            _Inout_updates_(length) float* pDst, _In_reads_(length) const float* pSrcA,
+            _In_reads_(length) float const* pSrcB, _In_reads_(length) const float* pSrcR, size_t length);
+
+        /* Find index of max element in vector */
+        uint32_t FindMaxIndex_32f(_In_ float* pVec, _In_ size_t const length);
+    } // namespace Arithmetic_Sse2
+} // namespace VectorMath
 #endif // defined(_M_IX86) || defined(_M_X64)

--- a/Source/Utilities/vectormath/vectormath_util.h
+++ b/Source/Utilities/vectormath/vectormath_util.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corp. All rights reserved
+
+#include <cstddef>
+
+#define IS_4BYTE_ALIGNED(p) (0 == (reinterpret_cast<ptrdiff_t>(p) & 0x03))
+#define IS_NOT_16BYTE_ALIGNED(p) (reinterpret_cast<ptrdiff_t>(p) & 0x0F)
+#define ARE_16BYTE_COALIGNED(pA, pB) (IS_NOT_16BYTE_ALIGNED(pA) == IS_NOT_16BYTE_ALIGNED(pB))
+#define ARE_ARRAYS_ALIGNED(pDst, pSrcA, pSrcB)                                                                         \
+    (IS_4BYTE_ALIGNED(pDst) && ARE_16BYTE_COALIGNED(pDst, pSrcA) && ARE_16BYTE_COALIGNED(pDst, pSrcB))

--- a/Source/include/AlignedAllocator.h
+++ b/Source/include/AlignedAllocator.h
@@ -4,15 +4,17 @@
 #if defined(ANDROID)
 #include <malloc.h>
 #endif
+#include <stdlib.h>
+#include <cstdlib>
 #include <vector>
-#include "VectorMath.h"
+#include "vectormath.h"
 
 namespace AlignedStore
 {
     // free standing aligned alloc and free functions
     inline void* aligned_malloc(size_t size, size_t alignment)
     {
-#if (WINDOWS || DURANGO)
+#if (WINDOWS || XBOX)
         return _aligned_malloc(size, alignment);
 #elif (LINUX || APPLE)
         void* ptr = nullptr;
@@ -23,6 +25,8 @@ namespace AlignedStore
         return ptr;
 #elif (ANDROID)
         return memalign(alignment, size);
+#elif defined(__XTENSA__)
+        return aligned_alloc(alignment, size);
 #else
         static_assert(false, "Not a valid platform?");
         return nullptr;
@@ -31,9 +35,9 @@ namespace AlignedStore
 
     inline void aligned_free(void* ptr)
     {
-#if (WINDOWS || DURANGO)
+#if (WINDOWS || XBOX)
         _aligned_free(ptr);
-#elif (LINUX || ANDROID || APPLE)
+#elif (LINUX || ANDROID || APPLE) || defined(__XTENSA__)
         free(ptr);
 #endif
     }

--- a/Source/include/AlignedAllocator.h
+++ b/Source/include/AlignedAllocator.h
@@ -25,8 +25,6 @@ namespace AlignedStore
         return ptr;
 #elif (ANDROID)
         return memalign(alignment, size);
-#elif defined(__XTENSA__)
-        return aligned_alloc(alignment, size);
 #else
         static_assert(false, "Not a valid platform?");
         return nullptr;
@@ -37,7 +35,7 @@ namespace AlignedStore
     {
 #if (WINDOWS || XBOX)
         _aligned_free(ptr);
-#elif (LINUX || ANDROID || APPLE) || defined(__XTENSA__)
+#elif (LINUX || ANDROID || APPLE)
         free(ptr);
 #endif
     }

--- a/Source/include/AlignedBuffers.h
+++ b/Source/include/AlignedBuffers.h
@@ -121,7 +121,7 @@ namespace AlignedStore
     public:
         AlignedBuffers() = default;
 
-        AlignedBuffers(AlignedBuffers&& other)
+        AlignedBuffers(AlignedBuffers&& other) noexcept
             : AlignedBuffersConst<T, alignment>(other), m_Data(std::move(other.m_Data))
         {
         }
@@ -167,7 +167,8 @@ namespace AlignedStore
     private:
         T* GetPtrAt(uint32_t element)
         {
-            return reinterpret_cast<T*>(m_Data.get() + element * AlignedBuffersConst<T, alignment>::m_BytesPerBuffer);
+            return reinterpret_cast<T*>(
+                m_Data.get() + static_cast<uint32_t>(element * AlignedBuffersConst<T, alignment>::m_BytesPerBuffer));
         }
 
     private:

--- a/Source/include/MathConstants.h
+++ b/Source/include/MathConstants.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#ifndef M_E
+    constexpr float M_E = 2.71828182845904523536f;        // e
+    constexpr float M_LOG2E = 1.44269504088896340736f;    // log2(e)
+    constexpr float M_LOG10E = 0.434294481903251827651f;  // log10(e)
+    constexpr float M_LN2 = 0.693147180559945309417f;     // ln(2)
+    constexpr float M_LN10 = 2.30258509299404568402f;     // ln(10)
+    constexpr float M_PI = 3.14159265358979323846f;       // pi
+    constexpr float M_PI_2 = 1.57079632679489661923f;     // pi/2
+    constexpr float M_PI_4 = 0.785398163397448309616f;    // pi/4
+    constexpr float M_1_PI = 0.318309886183790671538f;    // 1/pi
+    constexpr float M_2_PI = 0.636619772367581343076f;    // 2/pi
+    constexpr float M_2_SQRTPI = 1.12837916709551257390f; // 2/sqrt(pi)
+    constexpr float M_SQRT2 = 1.41421356237309504880f;    // sqrt(2)
+    constexpr float M_SQRT1_2 = 0.707106781186547524401f; // 1/sqrt(2)
+#endif

--- a/Source/include/VectorMath.h
+++ b/Source/include/VectorMath.h
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
-
 #include <stdint.h>
 #include <vector>
 #include <cstddef>
@@ -18,4 +17,11 @@ namespace VectorMath
     {
         return 16;
     }
+
+    // Factory function returns platform-specific implementation
+    std::unique_ptr<IRealFft> CreateRealFft(unsigned int order);
+
+    // Factory function returns platform-specific implementation
+    std::shared_ptr<IRealFft> CreateSharedRealFft(unsigned int order);
+
 } // namespace VectorMath

--- a/Source/include/mathutility.h
+++ b/Source/include/mathutility.h
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
-
+#include "MathConstants.h"
 #include <cmath>
 #include <algorithm>
+
+constexpr float RadianToDeg = 180.0f / static_cast<float>(M_PI);
+constexpr float DegToRadian = static_cast<float>(M_PI) / 180.0f;
 
 inline float AmplitudeToDb(float amplitude)
 {
@@ -15,9 +18,25 @@ inline float DbToAmplitude(float dB)
     return std::pow(10.0f, dB / 20.0f);
 }
 
+inline float EnergyToDB(float Energy)
+{
+    return 10.0f * std::log10(Energy);
+}
+
+inline float DBToEnergy(float DB)
+{
+    return std::pow(10.0f, (DB / 10.0f));
+}
+
 inline float Clamp(float value, float floor, float cap) noexcept
 {
     return std::min(std::max(value, floor), cap);
+}
+
+template <class T>
+inline T Clamp(T val, T minval, T maxval)
+{
+    return val < minval ? minval : (val > maxval ? maxval : val);
 }
 
 inline bool IsPowerOfTwo(int n)
@@ -29,4 +48,61 @@ template <typename T>
 int Sgn(T val)
 {
     return (T(0) < val) - (val < T(0));
+}
+
+template <typename T>
+T FloorTowardsZero(T val)
+{
+    if (val < 0)
+    {
+        return -std::floor(-val);
+    }
+    else
+    {
+        return std::floor(val);
+    }
+}
+
+inline double Square(double x)
+{
+    return x * x;
+}
+
+inline float Square(float x)
+{
+    return x * x;
+}
+
+// Conversion from 3D vector to spherical azimuth & elevation coordinates (in degrees).
+// Note this uses the Windows coordinate system (x+ right, y+ up, z- forward)
+//
+// Returns a pair of spherical coordinates (in degrees), with the following ranges:
+//   Azimuth . . . . . .   0 to 360* (not containing 360 itself),
+//   Elevation . . . . . -90 to  90,
+//
+inline std::pair<float, float> VectorToSpherical(const VectorF& vec) noexcept
+{
+    constexpr float eps = 1e-4f;
+    const float horizontalLength = sqrtf(vec.x * vec.x + vec.z * vec.z);
+    const float azimuthRadians = horizontalLength > eps ? atan2f(-vec.x, -vec.z) : 0.0f;
+    const float elevationRadians = (horizontalLength + fabsf(vec.y)) > eps ? atan2f(vec.y, horizontalLength) : 0.0f;
+
+    // 0-360 degrees
+    float azimuthDegrees = fmodf(fmodf(azimuthRadians * RadianToDeg, 360.0f) + 360.0f, 360.0f);
+
+    // -90-90 degrees
+    const float elevationDegrees = std::clamp(elevationRadians * RadianToDeg, -90.0f, 90.0f);
+
+    return std::make_pair(azimuthDegrees, elevationDegrees);
+}
+
+// Conversion from spherical coordinates (in degrees) to 3D vector.
+// Note this uses the Windows coordinate system (x+ right, y+ up, z- forward).
+inline VectorF SphericalToVector(float azimuthDegrees, float elevationDegrees) noexcept
+{
+    const float azimuthRadians = azimuthDegrees * DegToRadian;
+    const float elevationRadians = elevationDegrees * DegToRadian;
+
+    const float cosEle = cosf(elevationRadians);
+    return VectorF({-sinf(azimuthRadians) * cosEle, sinf(elevationRadians), -cosf(azimuthRadians) * cosEle});
 }

--- a/Source/include/vectormath_interfaces.h
+++ b/Source/include/vectormath_interfaces.h
@@ -4,10 +4,46 @@
 
 namespace VectorMath
 {
-   namespace Arithmetic
+
+    // Interface to a Fast Fourier Transform (FFT) for real-valued data.
+    class IRealFft
+    {
+    public:
+        // Forward FFT. Use GetFreqDomainBufferLength() to determine how many complex
+        // numbers to allocate for freqDomainBuffer.
+        virtual void ForwardFft(
+            const float* timeDomainBuffer, size_t timeDomainLen, floatFC* freqDomainBuffer,
+            size_t freqDomainLen) const = 0;
+
+        // Inverse FFT. Use GetFreqDomainBufferLength() to determine how many complex
+        // numbers to allocate for freqDomainBuffer.
+        virtual void InverseFft(
+            const floatFC* freqDomainBuffer, size_t freqDomainLen, float* timeDomainBuffer,
+            size_t timeDomainLen) const = 0;
+
+        // Return the number of complex numbers comprising one frequency domain vector.
+        virtual unsigned int GetFreqDomainBufferLength() const noexcept = 0;
+        virtual uint32_t GetTimeDomainBufferLength() const noexcept = 0;
+
+        virtual ~IRealFft(){};
+
+        /* On the topic of frequency domain data storage:
+         * Frequency domain data used by objects implementing this interface shall be stored
+         * in Intel's CCS data format. This format stores the first non-redundant complex numbers
+         * from the theoretical FFT result. For example, for a 1024-point FFT, the frequency
+         * domain output is 513 complex numbers, i.e. 1026 floats.
+         *
+         * The imaginary parts of the first and last elements are therefore always zero.
+         */
+    };
+
+    namespace Arithmetic
     {
         /* Sum two float vectors and store the result vector into the destination vector */
         void Add_32f(float* pDst, float const* pSrc1, float const* pSrc2, size_t const length);
+
+        /* Sum three float vectors and store the result vector into the destination vector */
+        void Add_32f(float* pDst, float const* pSrc1, float const* pSrc2, float const* pSrc3, size_t const length);
 
         /* Add float array to another */
         void Add_32f_I(float* pSrcDst, float const* pSrc, size_t const length);
@@ -18,6 +54,12 @@ namespace VectorMath
         /* Sum two complex number float vectors and store the result vector into
         the destination vector */
         void Add_32fc(floatFC* pDst, floatFC const* pSrc1, floatFC const* pSrc2, size_t const length);
+
+        /* Subtract two float vectors and store the result vector into the destination vector */
+        void Sub_32f(float* pDst, float const* pSrc1, float const* pSrc2, size_t const length);
+
+        /* Subtract two complex float vectors and store the result vector into the destination vector */
+        void Sub_32fc(floatFC* pDst, floatFC const* pSrc1, floatFC const* pSrc2, size_t const length);
 
         /* multiply 2 arrays of complex floats numbers and save the result into
         the destination vector */
@@ -64,6 +106,25 @@ namespace VectorMath
         void DotProd_32f(
             _Out_writes_(1) float* pDst, _In_reads_(length) float const* pSrc1, _In_reads_(length) float const* pSrc2,
             _In_ size_t const length);
+
+        /* Multiply source vectors by corresponding constant, sum the results, and save to output vector */
+        void DotProdC_32f(
+            _Out_ float* pDst, _In_reads_(length) float const* pSrc1, _In_reads_(length) float const* pSrc2,
+            _In_reads_(length) float const* pSrc3, _In_ float const val1, _In_ float const val2, _In_ float const val3,
+            _In_ size_t length);
+
+        /* Find index of max element in vector */
+        uint32_t FindMaxIndex_32f(_In_ float* pVec, _In_ size_t const length);
+
+        /* Solve the modified interpolation equation: a + (remainder * (b - a)) */
+        void Interpolate_32f(
+            _Inout_updates_(length) float* pDst, _In_reads_(length) const float* pSrcA,
+            _In_reads_(length) float const* pSrcB, _In_reads_(length) const float* pSrcR, size_t length);
+
+        /* Solve the modified interpolation equation: a + (remainder * (b - a)) */
+        void InterpolateC_32f(
+            _Inout_updates_(length) float* pDst, _In_reads_(length) const float* pSrcA,
+            _In_reads_(length) float const* pSrcB, _In_ float const remainder, size_t length);
     } // namespace Arithmetic
 
 } // namespace VectorMath


### PR DESCRIPTION
- Incorrect metadata on plugin binaries was causing load failures on Android
- Picked up new VectorMath headers with a Neon fix that addresses buzzing on Android  
