### PR TITLE
Update Unity plugin to use latest Flex DSP

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -27,7 +27,7 @@ endif ()
 set (EXTERNAL_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/External)
 
 # HrtfDsp Version and Path
-set (HRTFDSP_VERSION "Microsoft.ProjectAcoustics.HrtfDsp.3.0.130-prerelease")
+set (HRTFDSP_VERSION "Microsoft.ProjectAcoustics.HrtfDsp.3.0.418")
 
 include_directories (
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/Tools/packages.config
+++ b/Tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ProjectAcoustics.HrtfDsp" version="3.0.130-prerelease" targetFramework="native" />
+  <package id="Microsoft.ProjectAcoustics.HrtfDsp" version="3.0.418" targetFramework="native" />
 </packages>


### PR DESCRIPTION
In preparation for merging develop to master due to the build pipeline updates for Analog OnPrem going away, update the HrtfDsp version to the latest non-prerelease version on the AIPMR feed.

Tested by importing built unity plugin package from a topic branch with this change and hooked up to a sound source to verify spatialization was functioning properly.