### PR TITLE
Update filename to sign

### DIFF
--- a/Pipelines/Templates/Sign.yaml
+++ b/Pipelines/Templates/Sign.yaml
@@ -47,7 +47,7 @@ jobs:
     inputs:
       ConnectedServiceName: $(ESRPConnection)
       FolderPath: '$(Pipeline.Workspace)\BuildArtifacts'
-      Pattern: 'AudioPluginMicrosoftSpatializer.dll'
+      Pattern: 'AudioPluginMicrosoftSpatializerCrossPlatform.dll'
       SessionTimeout: 360
       MaxConcurrency: 5
       MaxRetryAttempts: 5


### PR DESCRIPTION
The signing task couldn't find the file AudioPluginMicrosoftSpatializer.dll since the filename had changed.  Update filename to reflect current name.
