### PR TITLE
Move off Analog-1ES-WindowsLatest pool

### DIFF
--- a/Pipelines/Templates/BuildAndroid.yaml
+++ b/Pipelines/Templates/BuildAndroid.yaml
@@ -17,10 +17,13 @@ parameters:
 
 jobs:
 - job: Android_${{ parameters.jobName }}_${{ parameters.configuration }}
+  continueOnError: false
   pool:
-    name: Analog-1ES-WindowsLatest
     vmImage: 'windows-2019'
-  dependsOn: []
+    Demands:
+    - msbuild
+    - visualstudio
+
   steps:
   - checkout: self
     submodules: true


### PR DESCRIPTION
Validation pipeline didn't run in MS ADO on Analog-1ES-WindowsLatest pool so move to the public pool since Android builds don't need anything special.

Validated both release and validation pipeline against this topic branch.