### PR TITLE
added missing platform setting to HrtfDsp.dll metadata

### DIFF
--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/x86_64/HrtfDsp.dll.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/Plugins/x86_64/HrtfDsp.dll.meta
@@ -65,7 +65,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: None
+        CPU: x86_64
   - first:
       Windows Store Apps: WindowsStoreApps
     second:


### PR DESCRIPTION
this change fixes an error about missing dll in x86_64 builds

reported in https://github.com/microsoft/spatialaudio-unity/issues/83