### PR TITLE
Updating unity package so it meets Unity Asset Store requirements

### DIFF
--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/CHANGELOG.md
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/).
+
+## [2.0.38] - 2024-01-19
+
+### Added
+
+- Support for UPM package publishing in the Unity Asset Store.

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/CHANGELOG.md.meta
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b79012f526875de49a404ba8614853d9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/package.json
+++ b/Source/Plugins/CrossPlatformPluginGenerator/Assets/Microsoft.SpatialAudio.Spatializer.Unity/package.json
@@ -1,10 +1,12 @@
 {
   "name": "com.microsoft.spatialaudio.spatializer.unity",
   "displayName": "Microsoft Spatializer",
-  "version": "%version%",
-  "unity": "2019.4",
+  "version": "2.0.38",
+  "unity": "2021.3",
+  "unityRelease": "26f1",
   "description": "Cross-platform Audio Spatializer for Mixed Reality and Immersive 3D applications",
   "msftFeatureCategory": "Spatial Audio",
+  "documentationUrl": "https://aka.ms/spatial-sound-unity",
   "keywords": [
     "microsoft",
     "mixed",


### PR DESCRIPTION
Microsoft will be publishing their most recent Mixed Reality UPMs to the Unity Asset Store.  In prepartion for this, this Stapial Audio package must be updated to meet Unity's requirements.

The following were changed to meet Unity's requirements

- Minimum version of Unity updated to 2021.3.26f1. This is the minimium version of Unity supported by the UPM Asset Store.
- Added the `unityRelease`.  This is required by the UPM Asset Store.
- Added a CHANGELOG.md that follows the [Keep a Changelog](http://keepachangelog.com/en/1.1.0/) formatting.
- Added `documentationUrl`. This is required by the UPM Asset Store.