### PR TITLE
Ensure .NET Core 2.1.x installed for signing

### DIFF
--- a/Pipelines/Templates/Sign.yaml
+++ b/Pipelines/Templates/Sign.yaml
@@ -40,6 +40,11 @@ jobs:
       scanType: 'Register'
       verbosity: 'Verbose'
       alertWarningLevel: 'High'
+  - task: UseDotNet@2
+    displayName: 'Ensure .NET Core is present for ESRP code signing'
+    inputs:
+      packageType: 'sdk'
+      version: 2.1.x
   - task: EsrpCodeSigning@1
     displayName: 'CodeSign Binaries'
     env:


### PR DESCRIPTION
Add task to signing template to ensure .NET Core 2.1.x is installed as required by the ESRP signing task